### PR TITLE
[codex] Publish package to JSR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   # Tests already passed before tag was created, so just build and deploy
   deploy:
     runs-on: ubuntu-latest
-    name: "Build and publish to npm"
+    name: "Build and publish to npm and JSR"
     permissions:
       contents: write
       id-token: write
@@ -52,6 +52,17 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --tag next --provenance --access public
+      - name: Sync JSR version
+        run: |
+          bun --eval "
+          const fs = require('node:fs');
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const jsr = JSON.parse(fs.readFileSync('jsr.json', 'utf8'));
+          jsr.version = pkg.version;
+          fs.writeFileSync('jsr.json', JSON.stringify(jsr, null, 2) + '\n');
+          "
+      - name: Publish to JSR
+        run: bunx jsr publish --provenance --allow-dirty
       - name: Create GitHub release
         id: create_release
         uses: softprops/action-gh-release@v3

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,19 @@
+{
+  "name": "@capgo/native-purchases",
+  "version": "8.3.10",
+  "exports": "./src/index.ts",
+  "publish": {
+    "include": [
+      "src/**/*.ts",
+      "android/src/main/**",
+      "android/build.gradle",
+      "ios/Sources/**",
+      "ios/Tests/**",
+      "Package.swift",
+      "CapgoNativePurchases.podspec",
+      "README.md",
+      "LICENSE",
+      "package.json"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,20 +35,20 @@
     "subscriptions"
   ],
   "scripts": {
-    "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
+    "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
     "verify:ios": "xcodebuild -scheme CapgoNativePurchases -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
-    "verify:web": "npm run build",
-    "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
-    "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
-    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
+    "verify:web": "bun run build",
+    "build": "bun run clean && bun run docgen && tsc && rollup -c rollup.config.mjs",
+    "lint": "bun run eslint && bun run prettier -- --check && bun run swiftlint -- lint",
+    "fmt": "bun run eslint -- --fix && bun run prettier -- --write && bun run swiftlint -- --fix --format",
     "eslint": "eslint . --ext ts",
     "prettier": "prettier-pretty-check \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api NativePurchasesPlugin --output-readme README.md --output-json dist/docs.json",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "bun run build"
   },
   "devDependencies": {
     "@capacitor/android": "^8.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { registerPlugin } from '@capacitor/core';
 
 import type { NativePurchasesPlugin } from './definitions';
 
-const NativePurchases = registerPlugin<NativePurchasesPlugin>('NativePurchases', {
+const NativePurchases: NativePurchasesPlugin = registerPlugin<NativePurchasesPlugin>('NativePurchases', {
   web: () => import('./web').then((m) => new m.NativePurchasesWeb()),
 });
 


### PR DESCRIPTION
## What
- Publish release tags to both npm and JSR.
- Add JSR package metadata for @capgo/native-purchases.
- Keep package script chaining on Bun.

## Why
- Release automation should publish the package to JSR in addition to npm.
- JSR requires explicit package metadata and explicit exported public API types.

## How
- Added jsr.json with source exports and publish includes for native plugin files.
- Added JSR version sync in the tag release workflow before running bunx jsr publish.
- Added an explicit NativePurchasesPlugin type annotation to satisfy JSR publish checks.
- Replaced internal npm run script chaining with bun run.

## Testing
- bunx jsr publish --dry-run --allow-dirty
- bun run build
- bun run verify:web
- bun run lint
- bun run verify:ios
- JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME='/Users/martindonadieu/Library/Android/sdk' ./gradlew clean build test -Dorg.gradle.workers.max=1 -Dandroid.aapt2DaemonMaxPoolSize=1

## Not Tested
- Real JSR publish from GitHub Actions. The JSR package must be linked to this GitHub repository in JSR settings for OIDC publishing.

AI-assisted by Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package is now published to JSR (JavaScript Registry), providing developers with an additional package registry option alongside npm.

* **Chores**
  * Migrated build toolchain from npm to Bun for improved performance and faster development cycles.
  * Version updated to 8.3.10.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-purchases/pull/176)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->