### PR TITLE
feat: add getStorefront() to read the App Store / Google Play storefront country

### DIFF
--- a/README.md
+++ b/README.md
@@ -1718,6 +1718,7 @@ This approach balances immediate user gratification with proper server-side vali
 * [`manageSubscriptions()`](#managesubscriptions)
 * [`acknowledgePurchase(...)`](#acknowledgepurchase)
 * [`consumePurchase(...)`](#consumepurchase)
+* [`getStorefront()`](#getstorefront)
 * [`addListener('transactionUpdated', ...)`](#addlistenertransactionupdated-)
 * [`addListener('transactionVerificationFailed', ...)`](#addlistenertransactionverificationfailed-)
 * [`removeAllListeners()`](#removealllisteners)
@@ -1990,6 +1991,38 @@ On iOS and web, this method rejects with an error.
 | **`options`** | <code>{ purchaseToken: string; }</code> | - The purchase to consume |
 
 **Since:** 8.2.0
+
+--------------------
+
+
+### getStorefront()
+
+```typescript
+getStorefront() => Promise<{ countryCode: string; storefrontId?: string; }>
+```
+
+Get the user's current App Store / Google Play storefront — the country
+their store account is registered to.
+
+iOS: reads StoreKit 2 `Storefront.current`. `countryCode` is ISO 3166-1
+**alpha-3** (e.g. `"USA"`) and `storefrontId` is the Apple-defined
+storefront identifier.
+Android: reads Google Play Billing `getBillingConfigAsync()`. `countryCode`
+is ISO 3166-1 **alpha-2** (e.g. `"US"`); `storefrontId` is omitted (Google
+Play has no storefront-id concept).
+
+Resolves a `countryCode` of `""` (it does not reject) when the storefront
+can't be determined on either platform — e.g. apps distributed via iOS
+alternative distribution, or Google Play billing being unavailable.
+
+Useful for region-dependent logic such as localized offers/pricing and
+gating external-purchase entitlements, whose eligibility the platforms key
+to the storefront country. Read it live rather than caching, since the user
+can change their store region.
+
+**Returns:** <code>Promise&lt;{ countryCode: string; storefrontId?: string; }&gt;</code>
+
+**Since:** 8.5.0
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -2011,6 +2011,13 @@ Android: reads Google Play Billing `getBillingConfigAsync()`. `countryCode`
 is ISO 3166-1 **alpha-2** (e.g. `"US"`); `storefrontId` is omitted (Google
 Play has no storefront-id concept).
 
+Contract note (future-major default candidate): `countryCode` is returned in
+each store's native format and is intentionally NOT normalized across
+platforms today (iOS alpha-3 vs Android alpha-2), to stay faithful to the
+platform APIs. Normalizing both to a single scheme (e.g. ISO 3166-1 alpha-2)
+is a candidate default change for the next Capacitor major, deferred so it
+can be adopted deliberately rather than as a mid-major breaking change.
+
 Resolves a `countryCode` of `""` (it does not reject) when the storefront
 can't be determined on either platform — e.g. apps distributed via iOS
 alternative distribution, or Google Play billing being unavailable.

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -10,9 +10,12 @@ import com.android.billingclient.api.AcknowledgePurchaseParams;
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
+import com.android.billingclient.api.BillingConfig;
+import com.android.billingclient.api.BillingConfigResponseListener;
 import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeParams;
+import com.android.billingclient.api.GetBillingConfigParams;
 import com.android.billingclient.api.PendingPurchasesParams;
 import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.ProductDetailsResponseListener;
@@ -76,6 +79,57 @@ public class NativePurchasesPlugin extends Plugin {
             Log.d(TAG, "isBillingSupported() returning false - unexpected error");
             call.resolve(ret);
         }
+    }
+
+    @PluginMethod
+    public void getStorefront(PluginCall call) {
+        Log.d(TAG, "getStorefront() called");
+        try {
+            // Pass null so initBillingClient doesn't reject the call - getStorefront
+            // always resolves and reports an empty countryCode when the storefront
+            // can't be determined, mirroring isBillingSupported() and the iOS side.
+            this.initBillingClient(null);
+        } catch (RuntimeException e) {
+            Log.e(TAG, "getStorefront() - billing client init failed: " + e.getMessage());
+            closeBillingClient();
+            call.resolve(emptyStorefront());
+            return;
+        }
+        try {
+            billingClient.getBillingConfigAsync(
+                GetBillingConfigParams.newBuilder().build(),
+                new BillingConfigResponseListener() {
+                    @Override
+                    public void onBillingConfigResponse(@NonNull BillingResult billingResult, BillingConfig billingConfig) {
+                        JSObject ret = new JSObject();
+                        if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK && billingConfig != null) {
+                            String countryCode = billingConfig.getCountryCode();
+                            Log.d(TAG, "getBillingConfig success, countryCode: " + countryCode);
+                            // JSObject.put(name, null) removes the key, so coalesce to "".
+                            ret.put("countryCode", countryCode != null ? countryCode : "");
+                        } else {
+                            Log.e(
+                                TAG,
+                                "getBillingConfig unavailable: " + billingResult.getResponseCode() + " - " + billingResult.getDebugMessage()
+                            );
+                            ret.put("countryCode", "");
+                        }
+                        closeBillingClient();
+                        call.resolve(ret);
+                    }
+                }
+            );
+        } catch (Exception e) {
+            Log.e(TAG, "getBillingConfigAsync threw: " + e.getMessage());
+            closeBillingClient();
+            call.resolve(emptyStorefront());
+        }
+    }
+
+    private JSObject emptyStorefront() {
+        JSObject ret = new JSObject();
+        ret.put("countryCode", "");
+        return ret;
     }
 
     @Override

--- a/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
+++ b/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
@@ -18,7 +18,8 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "acknowledgePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "consumePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getAppTransaction", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "isEntitledToOldBusinessModel", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "isEntitledToOldBusinessModel", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getStorefront", returnType: CAPPluginReturnPromise)
     ]
 
     private let pluginVersion: String = "8.4.6"
@@ -69,6 +70,25 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func isBillingSupported(_ call: CAPPluginCall) {
         call.resolve(["isBillingSupported": true])
+    }
+
+    @objc func getStorefront(_ call: CAPPluginCall) {
+        print("getStorefront")
+        Task {
+            let storefront = await Storefront.current
+            await MainActor.run {
+                if let storefront = storefront {
+                    call.resolve([
+                        "countryCode": storefront.countryCode,
+                        "storefrontId": storefront.id
+                    ])
+                } else {
+                    // No storefront (e.g. alternative distribution).
+                    print("getStorefront: no storefront available")
+                    call.resolve(["countryCode": ""])
+                }
+            }
+        }
     }
 
     @objc func purchaseProduct(_ call: CAPPluginCall) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1276,6 +1276,39 @@ export interface NativePurchasesPlugin {
   consumePurchase(options: { purchaseToken: string }): Promise<void>;
 
   /**
+   * Get the user's current App Store / Google Play storefront — the country
+   * their store account is registered to.
+   *
+   * iOS: reads StoreKit 2 `Storefront.current`. `countryCode` is ISO 3166-1
+   * **alpha-3** (e.g. `"USA"`) and `storefrontId` is the Apple-defined
+   * storefront identifier.
+   * Android: reads Google Play Billing `getBillingConfigAsync()`. `countryCode`
+   * is ISO 3166-1 **alpha-2** (e.g. `"US"`); `storefrontId` is omitted (Google
+   * Play has no storefront-id concept).
+   *
+   * Resolves a `countryCode` of `""` (it does not reject) when the storefront
+   * can't be determined on either platform — e.g. apps distributed via iOS
+   * alternative distribution, or Google Play billing being unavailable.
+   *
+   * Useful for region-dependent logic such as localized offers/pricing and
+   * gating external-purchase entitlements, whose eligibility the platforms key
+   * to the storefront country. Read it live rather than caching, since the user
+   * can change their store region.
+   *
+   * @returns {Promise<{ countryCode: string; storefrontId?: string }>} the current storefront
+   * @since 8.5.0
+   *
+   * @example
+   * ```typescript
+   * const { countryCode } = await NativePurchases.getStorefront();
+   * if (countryCode === 'USA' || countryCode === 'US') {
+   *   // show US-specific payment options
+   * }
+   * ```
+   */
+  getStorefront(): Promise<{ countryCode: string; storefrontId?: string }>;
+
+  /**
    * Listen for StoreKit transaction updates delivered by Apple's Transaction.updates.
    * Fires on app launch if there are unfinished transactions, and for any updates afterward.
    * iOS only.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1286,6 +1286,13 @@ export interface NativePurchasesPlugin {
    * is ISO 3166-1 **alpha-2** (e.g. `"US"`); `storefrontId` is omitted (Google
    * Play has no storefront-id concept).
    *
+   * Contract note (future-major default candidate): `countryCode` is returned in
+   * each store's native format and is intentionally NOT normalized across
+   * platforms today (iOS alpha-3 vs Android alpha-2), to stay faithful to the
+   * platform APIs. Normalizing both to a single scheme (e.g. ISO 3166-1 alpha-2)
+   * is a candidate default change for the next Capacitor major, deferred so it
+   * can be adopted deliberately rather than as a mid-major breaking change.
+   *
    * Resolves a `countryCode` of `""` (it does not reject) when the storefront
    * can't be determined on either platform — e.g. apps distributed via iOS
    * alternative distribution, or Google Play billing being unavailable.

--- a/src/web.ts
+++ b/src/web.ts
@@ -64,6 +64,11 @@ export class NativePurchasesWeb extends WebPlugin implements NativePurchasesPlug
     throw new Error('consumePurchase is only available on Android');
   }
 
+  async getStorefront(): Promise<{ countryCode: string; storefrontId?: string }> {
+    console.error('getStorefront only mocked in web');
+    return { countryCode: '' };
+  }
+
   async getAppTransaction(): Promise<{ appTransaction: AppTransaction }> {
     console.error('getAppTransaction only mocked in web');
     return {


### PR DESCRIPTION
## What
- Adds `getStorefront()` — reads the user's current App Store / Google Play storefront (the country their store account is registered to). Resolves `{ countryCode, storefrontId? }`.

## Why
- The plugin can read a product's currency but not the user's storefront country — the platform-blessed signal for region-dependent behavior:
  - Localized offers/pricing & regional catalogs (store region ≠ device locale, which the user can change independently of their store account).
  - Gating external-purchase / alternative-payment flows, increasingly relevant in 2025–2026. Apple and Google key eligibility to the production store account's storefront country, not device locale: US external-purchase links after the April 2025 *Epic v. Apple* injunction; EU (DMA), South Korea, Netherlands, Japan programs. Apple exposes it via `ExternalPurchaseCustomLink.isEligible`.

## How
- **iOS:** StoreKit 2 `await Storefront.current` → `{ countryCode (ISO 3166-1 alpha-3, "USA"), storefrontId }`; empty `countryCode` when no storefront is available (alternative distribution). No `#available` guard (plugin min is iOS 15).
- **Android:** `BillingClient.getBillingConfigAsync()` → `{ countryCode (ISO 3166-1 alpha-2, "US") }`, reusing the existing `initBillingClient(...)` / `closeBillingClient()` lifecycle. Modeled on `isBillingSupported()` (passes `null` to `initBillingClient`) so it always resolves and reports an empty `countryCode` on failure instead of rejecting — a consistent cross-platform contract. `getCountryCode()` is null-coalesced to `""` (org.json `put(null)` drops the key).
- **Web:** mocked stub returning `{ countryCode: '' }`, matching the other stubs.
- JSDoc in `src/definitions.ts` documents the per-platform format + empty-string contract; README regenerated via docgen. Registered in iOS `pluginMethods` and as an Android `@PluginMethod`; `check:wiring` passes.

## Testing
- `bun run build` (docgen + tsc + rollup), `bun run lint` (ESLint + Prettier; SwiftLint auto-skipped on Linux), `bun run verify:web`, and `scripts/check-capacitor-plugin-wiring.mjs` all pass.
- Confirmed the method is wired across all four surfaces (TS / iOS / Android / Web).

## Not Tested
- `bun run verify:ios` (xcodebuild) and `bun run verify:android` (gradlew) — no macOS/Android toolchain in my environment, so the native builds and on-device behavior weren't run; would appreciate a CI run. The Swift/Java follow existing in-file patterns and the documented native APIs (`Storefront.current` iOS 15+, `getBillingConfigAsync` Billing 6.1+).
- On-device values (TestFlight is known to report `"USA"` regardless of account region; EU alternative distribution can yield an empty storefront).

## Notes
- Prepared with AI assistance (per AGENTS.md's note welcoming AI contributions).
- Open to your preference on: the `@since` placeholder (`8.5.0`), whether to normalize the alpha-3/alpha-2 difference in-plugin vs. leave it per-platform, and a named return interface vs. the inline type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `getStorefront()` API to return the app store region info (with platform-specific ISO formats).
  * iOS now returns `countryCode` plus `storefrontId` when available.
  * Android returns the storefront `countryCode` when it can be determined (no storefront identifier).
  * Web returns a mocked empty storefront response for compatibility.
  * Added `isEntitledToOldBusinessModel` support on iOS.
* **Bug Fixes**
  * When storefront details can’t be determined, `getStorefront()` resolves with `countryCode: ""` instead of failing.
* **Documentation**
  * Updated API documentation, including availability since version `8.5.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->