### PR TITLE
feat: backport getStorefront() to the Capacitor 7 (v7) line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1674,6 +1674,7 @@ This approach balances immediate user gratification with proper server-side vali
 * [`manageSubscriptions()`](#managesubscriptions)
 * [`acknowledgePurchase(...)`](#acknowledgepurchase)
 * [`consumePurchase(...)`](#consumepurchase)
+* [`getStorefront()`](#getstorefront)
 * [`addListener('transactionUpdated', ...)`](#addlistenertransactionupdated-)
 * [`addListener('transactionVerificationFailed', ...)`](#addlistenertransactionverificationfailed-)
 * [`removeAllListeners()`](#removealllisteners)
@@ -1939,6 +1940,45 @@ On iOS and web, this method rejects with an error.
 | **`options`** | <code>{ purchaseToken: string; }</code> | - The purchase to consume |
 
 **Since:** 8.2.0
+
+--------------------
+
+
+### getStorefront()
+
+```typescript
+getStorefront() => Promise<{ countryCode: string; storefrontId?: string; }>
+```
+
+Get the user's current App Store / Google Play storefront — the country
+their store account is registered to.
+
+iOS: reads StoreKit 2 `Storefront.current`. `countryCode` is ISO 3166-1
+**alpha-3** (e.g. `"USA"`) and `storefrontId` is the Apple-defined
+storefront identifier.
+Android: reads Google Play Billing `getBillingConfigAsync()`. `countryCode`
+is ISO 3166-1 **alpha-2** (e.g. `"US"`); `storefrontId` is omitted (Google
+Play has no storefront-id concept).
+
+Contract note (future-major default candidate): `countryCode` is returned in
+each store's native format and is intentionally NOT normalized across
+platforms today (iOS alpha-3 vs Android alpha-2), to stay faithful to the
+platform APIs. Normalizing both to a single scheme (e.g. ISO 3166-1 alpha-2)
+is a candidate default change for the next Capacitor major, deferred so it
+can be adopted deliberately rather than as a mid-major breaking change.
+
+Resolves a `countryCode` of `""` (it does not reject) when the storefront
+can't be determined on either platform — e.g. apps distributed via iOS
+alternative distribution, or Google Play billing being unavailable.
+
+Useful for region-dependent logic such as localized offers/pricing and
+gating external-purchase entitlements, whose eligibility the platforms key
+to the storefront country. Read it live rather than caching, since the user
+can change their store region.
+
+**Returns:** <code>Promise&lt;{ countryCode: string; storefrontId?: string; }&gt;</code>
+
+**Since:** 7.19.0
 
 --------------------
 

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -10,9 +10,12 @@ import com.android.billingclient.api.AcknowledgePurchaseParams;
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
+import com.android.billingclient.api.BillingConfig;
+import com.android.billingclient.api.BillingConfigResponseListener;
 import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeParams;
+import com.android.billingclient.api.GetBillingConfigParams;
 import com.android.billingclient.api.PendingPurchasesParams;
 import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.ProductDetailsResponseListener;
@@ -77,6 +80,57 @@ public class NativePurchasesPlugin extends Plugin {
             Log.d(TAG, "isBillingSupported() returning false - unexpected error");
             call.resolve(ret);
         }
+    }
+
+    @PluginMethod
+    public void getStorefront(PluginCall call) {
+        Log.d(TAG, "getStorefront() called");
+        try {
+            // Pass null so initBillingClient doesn't reject the call - getStorefront
+            // always resolves and reports an empty countryCode when the storefront
+            // can't be determined, mirroring isBillingSupported() and the iOS side.
+            this.initBillingClient(null);
+        } catch (RuntimeException e) {
+            Log.e(TAG, "getStorefront() - billing client init failed: " + e.getMessage());
+            closeBillingClient();
+            call.resolve(emptyStorefront());
+            return;
+        }
+        try {
+            billingClient.getBillingConfigAsync(
+                GetBillingConfigParams.newBuilder().build(),
+                new BillingConfigResponseListener() {
+                    @Override
+                    public void onBillingConfigResponse(@NonNull BillingResult billingResult, BillingConfig billingConfig) {
+                        JSObject ret = new JSObject();
+                        if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK && billingConfig != null) {
+                            String countryCode = billingConfig.getCountryCode();
+                            Log.d(TAG, "getBillingConfig success, countryCode: " + countryCode);
+                            // JSObject.put(name, null) removes the key, so coalesce to "".
+                            ret.put("countryCode", countryCode != null ? countryCode : "");
+                        } else {
+                            Log.e(
+                                TAG,
+                                "getBillingConfig unavailable: " + billingResult.getResponseCode() + " - " + billingResult.getDebugMessage()
+                            );
+                            ret.put("countryCode", "");
+                        }
+                        closeBillingClient();
+                        call.resolve(ret);
+                    }
+                }
+            );
+        } catch (Exception e) {
+            Log.e(TAG, "getBillingConfigAsync threw: " + e.getMessage());
+            closeBillingClient();
+            call.resolve(emptyStorefront());
+        }
+    }
+
+    private JSObject emptyStorefront() {
+        JSObject ret = new JSObject();
+        ret.put("countryCode", "");
+        return ret;
     }
 
     @Override

--- a/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
+++ b/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
@@ -18,7 +18,8 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "acknowledgePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "consumePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getAppTransaction", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "isEntitledToOldBusinessModel", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "isEntitledToOldBusinessModel", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getStorefront", returnType: CAPPluginReturnPromise)
     ]
 
     private let pluginVersion: String = "7.18.0"
@@ -69,6 +70,25 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func isBillingSupported(_ call: CAPPluginCall) {
         call.resolve(["isBillingSupported": true])
+    }
+
+    @objc func getStorefront(_ call: CAPPluginCall) {
+        print("getStorefront")
+        Task {
+            let storefront = await Storefront.current
+            await MainActor.run {
+                if let storefront = storefront {
+                    call.resolve([
+                        "countryCode": storefront.countryCode,
+                        "storefrontId": storefront.id
+                    ])
+                } else {
+                    // No storefront (e.g. alternative distribution).
+                    print("getStorefront: no storefront available")
+                    call.resolve(["countryCode": ""])
+                }
+            }
+        }
     }
 
     @objc func purchaseProduct(_ call: CAPPluginCall) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1038,6 +1038,46 @@ export interface NativePurchasesPlugin {
   consumePurchase(options: { purchaseToken: string }): Promise<void>;
 
   /**
+   * Get the user's current App Store / Google Play storefront — the country
+   * their store account is registered to.
+   *
+   * iOS: reads StoreKit 2 `Storefront.current`. `countryCode` is ISO 3166-1
+   * **alpha-3** (e.g. `"USA"`) and `storefrontId` is the Apple-defined
+   * storefront identifier.
+   * Android: reads Google Play Billing `getBillingConfigAsync()`. `countryCode`
+   * is ISO 3166-1 **alpha-2** (e.g. `"US"`); `storefrontId` is omitted (Google
+   * Play has no storefront-id concept).
+   *
+   * Contract note (future-major default candidate): `countryCode` is returned in
+   * each store's native format and is intentionally NOT normalized across
+   * platforms today (iOS alpha-3 vs Android alpha-2), to stay faithful to the
+   * platform APIs. Normalizing both to a single scheme (e.g. ISO 3166-1 alpha-2)
+   * is a candidate default change for the next Capacitor major, deferred so it
+   * can be adopted deliberately rather than as a mid-major breaking change.
+   *
+   * Resolves a `countryCode` of `""` (it does not reject) when the storefront
+   * can't be determined on either platform — e.g. apps distributed via iOS
+   * alternative distribution, or Google Play billing being unavailable.
+   *
+   * Useful for region-dependent logic such as localized offers/pricing and
+   * gating external-purchase entitlements, whose eligibility the platforms key
+   * to the storefront country. Read it live rather than caching, since the user
+   * can change their store region.
+   *
+   * @returns {Promise<{ countryCode: string; storefrontId?: string }>} the current storefront
+   * @since 7.19.0
+   *
+   * @example
+   * ```typescript
+   * const { countryCode } = await NativePurchases.getStorefront();
+   * if (countryCode === 'USA' || countryCode === 'US') {
+   *   // show US-specific payment options
+   * }
+   * ```
+   */
+  getStorefront(): Promise<{ countryCode: string; storefrontId?: string }>;
+
+  /**
    * Listen for StoreKit transaction updates delivered by Apple's Transaction.updates.
    * Fires on app launch if there are unfinished transactions, and for any updates afterward.
    * iOS only.

--- a/src/web.ts
+++ b/src/web.ts
@@ -50,6 +50,11 @@ export class NativePurchasesWeb extends WebPlugin implements NativePurchasesPlug
     throw new Error('consumePurchase is only available on Android');
   }
 
+  async getStorefront(): Promise<{ countryCode: string; storefrontId?: string }> {
+    console.error('getStorefront only mocked in web');
+    return { countryCode: '' };
+  }
+
   async getAppTransaction(): Promise<{ appTransaction: AppTransaction }> {
     console.error('getAppTransaction only mocked in web');
     return {


### PR DESCRIPTION
## What
- Backports `getStorefront()` to the **Capacitor 7 (`v7`)** line — reads the user's current App Store / Google Play storefront (the country their store account is registered to). Resolves `{ countryCode, storefrontId? }`. Same method that shipped on the 8.x line in #190 / 8.5.0.

## Why
- `getStorefront` currently exists only on the 8.x line (Capacitor 8); Capacitor-7 apps on the `v7` line have no way to read the storefront. Storefront country is the platform-blessed signal for region-dependent behavior: localized offers/pricing & regional catalogs (store region ≠ device locale), and gating external-purchase / alternative-payment flows — Apple and Google key eligibility to the production store account's storefront country (US external links after the April 2025 *Epic v. Apple* injunction; EU DMA / Korea / Netherlands / Japan programs; Apple's `ExternalPurchaseCustomLink.isEligible`).

## How
- **iOS:** StoreKit 2 `await Storefront.current` → `{ countryCode (ISO 3166-1 alpha-3, "USA"), storefrontId }`; empty `countryCode` when no storefront (alternative distribution). No `#available` guard (v7 min is iOS 15).
- **Android:** `BillingClient.getBillingConfigAsync()` → `{ countryCode (ISO 3166-1 alpha-2, "US") }`, reusing the existing `initBillingClient(...)` / `closeBillingClient()` lifecycle. Modeled on `isBillingSupported()` (passes `null` to `initBillingClient`) so it always resolves and reports an empty `countryCode` on failure instead of rejecting — consistent cross-platform contract. `getCountryCode()` null-coalesced to `""` (org.json `put(null)` drops the key). v7 ships Billing 8.3.0, so `getBillingConfigAsync` (Billing 6.1+) is available.
- **Web:** mocked stub returning `{ countryCode: '' }`.
- JSDoc + README regenerated via docgen. The implementation mirrors the merged 8.x version exactly.

## Testing
- `bun run build` (docgen + tsc + rollup) passes; `prettier --check` is clean on the changed TS (`src/definitions.ts`, `src/web.ts`). Confirmed `getStorefront` is wired across TS / iOS / Android / Web.
- Behaviorally identical to the already-merged 8.x implementation (#190, shipped in 8.5.0).

## Not Tested
- `bun run verify:ios` (xcodebuild) and `verify:android` (gradlew) — no macOS/Android toolchain in my environment, so native builds and on-device behavior weren't run; would appreciate a CI run.
- I deliberately did **not** run `prettier --write` on `android/.../NativePurchasesPlugin.java`: the pristine `v7` file already reports prettier style issues under the lockfile-pinned `prettier` / `prettier-plugin-java` (pre-existing, on lines unrelated to this change), so a `--write` would have reformatted unrelated code. The added `getStorefront` block follows the existing style and is byte-identical to the merged 8.x version. Happy to bundle a full `fmt` if you'd prefer.

## Notes
- Prepared with AI assistance (per AGENTS.md).
- `@since 7.19.0` is a placeholder (next minor from 7.18.0); I left the native `pluginVersion` / `package.json` untouched since version state is release-managed — adjust as needed.
- **Heads-up (separate from this PR):** the `v7` line's `@capacitor/core` peerDependency is `>=8.0.0` (since 7.17.0; 7.16.2 had `>=7.0.0`). That declares Capacitor 8 on the Capacitor-7 line, which surfaces a peer warning for Cap-7 consumers and partly defeats having a v7 line. Flagging in case it's unintended — happy to restore `>=7.0.0` on `v7` here or in a separate PR.
