### PR TITLE
feat: backport getStorefront() to lts-v7 with auto-publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,10 @@ on:
 jobs:
   # Tests already passed before tag was created, so just build and deploy
   deploy:
-    timeout-minutes: 30
+    # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
+    timeout-minutes: 10
     runs-on: ubuntu-latest
-    name: "Build and publish to npm"
+    name: "Build code and npm release"
     permissions:
       contents: write
       id-token: write
@@ -28,6 +29,8 @@ jobs:
       - name: Install dependencies
         id: install_code
         run: bun i
+      - name: Check plugin wiring
+        run: bun run check:wiring
       - name: Build
         id: build_code
         run: bun run build
@@ -38,29 +41,38 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model: claude-sonnet-4-5-20250929
-      - uses: js-devtools/npm-publish@v4
-        if: ${{ !contains(github.ref, '-alpha.') }}
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v6
         with:
-          token: ${{ secrets.NPM_TOKEN }}
-          provenance: true
-      - uses: js-devtools/npm-publish@v4
-        if: ${{ contains(github.ref, '-alpha.') }}
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          tag: next
-          provenance: true
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+      - name: Publish lts-v7 to npm
+        if: ${{ startsWith(github.ref, 'refs/tags/7.') }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag lts-v7 --provenance --access public
+      - name: Publish to npm
+        if: ${{ !contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/7.') }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag latest --provenance --access public
+      - name: Publish to npm with next tag
+        if: ${{ contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/7.') }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag next --provenance --access public
       - name: Create GitHub release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body: |
             ## 🆕 Changelog
-            
+
             ${{ steps.changelog.outputs.result }}
-            
+
             ---
 
             🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag }}...${{ steps.changelog.outputs.to_tag }}
-          make_latest: true
+          make_latest: ${{ !contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/7.') }}
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
           prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Install dependencies
         id: install_code
         run: bun i
-      - name: Check plugin wiring
-        run: bun run check:wiring
       - name: Build
         id: build_code
         run: bun run build

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -5,14 +5,17 @@ on:
     branches:
       - main
       - development
+      - lts-v7
     paths-ignore:
       - 'example-app/**'
       - '.github/**'
+  workflow_dispatch:
 
 jobs:
   # Run all tests first before creating any tags
   test:
     if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    # Called workflow jobs are capped at 10 minutes; never raise that unless explicitly asked.
     uses: ./.github/workflows/test.yml
 
   # Only bump version and create tag if all tests pass
@@ -20,8 +23,14 @@ jobs:
     needs: [test]
     if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
+    # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
+    timeout-minutes: 10
     name: "Bump version and create tag"
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
       - name: Check out
         uses: actions/checkout@v6
         with:
@@ -46,11 +55,16 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: bunx capacitor-plugin-standard-version@latest --skip.changelog
       - name: Create version bump development
-        if: github.ref != 'refs/heads/main'
+        if: github.ref == 'refs/heads/development'
         run: bunx capacitor-plugin-standard-version@latest --prerelease alpha --skip.changelog
+      - name: Create version bump lts-v7
+        if: github.ref == 'refs/heads/lts-v7'
+        run: bunx capacitor-plugin-standard-version@latest --skip.changelog
       - name: Push to origin
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           remote_repo="https://${GITHUB_ACTOR}:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
-          git pull $remote_repo $CURRENT_BRANCH
+          git add -A
+          git diff --staged --quiet || git commit -m "chore: commit any remaining changes" || true
+          git pull --rebase $remote_repo $CURRENT_BRANCH
           git push $remote_repo HEAD:$CURRENT_BRANCH --follow-tags --tags

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - renovate/**
   pull_request:
-    branches: [ main ]
+    branches: [main, lts-v7]
+  workflow_dispatch:
   workflow_call:  # Allow this workflow to be called by other workflows
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1674,6 +1674,7 @@ This approach balances immediate user gratification with proper server-side vali
 * [`manageSubscriptions()`](#managesubscriptions)
 * [`acknowledgePurchase(...)`](#acknowledgepurchase)
 * [`consumePurchase(...)`](#consumepurchase)
+* [`getStorefront()`](#getstorefront)
 * [`addListener('transactionUpdated', ...)`](#addlistenertransactionupdated-)
 * [`addListener('transactionVerificationFailed', ...)`](#addlistenertransactionverificationfailed-)
 * [`removeAllListeners()`](#removealllisteners)
@@ -1939,6 +1940,45 @@ On iOS and web, this method rejects with an error.
 | **`options`** | <code>{ purchaseToken: string; }</code> | - The purchase to consume |
 
 **Since:** 8.2.0
+
+--------------------
+
+
+### getStorefront()
+
+```typescript
+getStorefront() => Promise<{ countryCode: string; storefrontId?: string; }>
+```
+
+Get the user's current App Store / Google Play storefront — the country
+their store account is registered to.
+
+iOS: reads StoreKit 2 `Storefront.current`. `countryCode` is ISO 3166-1
+**alpha-3** (e.g. `"USA"`) and `storefrontId` is the Apple-defined
+storefront identifier.
+Android: reads Google Play Billing `getBillingConfigAsync()`. `countryCode`
+is ISO 3166-1 **alpha-2** (e.g. `"US"`); `storefrontId` is omitted (Google
+Play has no storefront-id concept).
+
+Contract note (future-major default candidate): `countryCode` is returned in
+each store's native format and is intentionally NOT normalized across
+platforms today (iOS alpha-3 vs Android alpha-2), to stay faithful to the
+platform APIs. Normalizing both to a single scheme (e.g. ISO 3166-1 alpha-2)
+is a candidate default change for the next Capacitor major, deferred so it
+can be adopted deliberately rather than as a mid-major breaking change.
+
+Resolves a `countryCode` of `""` (it does not reject) when the storefront
+can't be determined on either platform — e.g. apps distributed via iOS
+alternative distribution, or Google Play billing being unavailable.
+
+Useful for region-dependent logic such as localized offers/pricing and
+gating external-purchase entitlements, whose eligibility the platforms key
+to the storefront country. Read it live rather than caching, since the user
+can change their store region.
+
+**Returns:** <code>Promise&lt;{ countryCode: string; storefrontId?: string; }&gt;</code>
+
+**Since:** 7.19.0
 
 --------------------
 

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -581,8 +581,9 @@ public class NativePurchasesPlugin extends Plugin {
                             }
                             productDetailsParamsList.add(productDetailsParams.build());
                         }
-                        BillingFlowParams.Builder billingFlowBuilder = BillingFlowParams.newBuilder()
-                            .setProductDetailsParamsList(productDetailsParamsList);
+                        BillingFlowParams.Builder billingFlowBuilder = BillingFlowParams.newBuilder().setProductDetailsParamsList(
+                            productDetailsParamsList
+                        );
                         if (accountIdentifier != null && !accountIdentifier.isEmpty()) {
                             billingFlowBuilder.setObfuscatedAccountId(accountIdentifier);
                         }

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -10,9 +10,12 @@ import com.android.billingclient.api.AcknowledgePurchaseParams;
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
+import com.android.billingclient.api.BillingConfig;
+import com.android.billingclient.api.BillingConfigResponseListener;
 import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeParams;
+import com.android.billingclient.api.GetBillingConfigParams;
 import com.android.billingclient.api.PendingPurchasesParams;
 import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.ProductDetailsResponseListener;
@@ -77,6 +80,57 @@ public class NativePurchasesPlugin extends Plugin {
             Log.d(TAG, "isBillingSupported() returning false - unexpected error");
             call.resolve(ret);
         }
+    }
+
+    @PluginMethod
+    public void getStorefront(PluginCall call) {
+        Log.d(TAG, "getStorefront() called");
+        try {
+            // Pass null so initBillingClient doesn't reject the call - getStorefront
+            // always resolves and reports an empty countryCode when the storefront
+            // can't be determined, mirroring isBillingSupported() and the iOS side.
+            this.initBillingClient(null);
+        } catch (RuntimeException e) {
+            Log.e(TAG, "getStorefront() - billing client init failed: " + e.getMessage());
+            closeBillingClient();
+            call.resolve(emptyStorefront());
+            return;
+        }
+        try {
+            billingClient.getBillingConfigAsync(
+                GetBillingConfigParams.newBuilder().build(),
+                new BillingConfigResponseListener() {
+                    @Override
+                    public void onBillingConfigResponse(@NonNull BillingResult billingResult, BillingConfig billingConfig) {
+                        JSObject ret = new JSObject();
+                        if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK && billingConfig != null) {
+                            String countryCode = billingConfig.getCountryCode();
+                            Log.d(TAG, "getBillingConfig success, countryCode: " + countryCode);
+                            // JSObject.put(name, null) removes the key, so coalesce to "".
+                            ret.put("countryCode", countryCode != null ? countryCode : "");
+                        } else {
+                            Log.e(
+                                TAG,
+                                "getBillingConfig unavailable: " + billingResult.getResponseCode() + " - " + billingResult.getDebugMessage()
+                            );
+                            ret.put("countryCode", "");
+                        }
+                        closeBillingClient();
+                        call.resolve(ret);
+                    }
+                }
+            );
+        } catch (Exception e) {
+            Log.e(TAG, "getBillingConfigAsync threw: " + e.getMessage());
+            closeBillingClient();
+            call.resolve(emptyStorefront());
+        }
+    }
+
+    private JSObject emptyStorefront() {
+        JSObject ret = new JSObject();
+        ret.put("countryCode", "");
+        return ret;
     }
 
     @Override

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -44,7 +44,7 @@ import org.json.JSONArray;
 @CapacitorPlugin(name = "NativePurchases")
 public class NativePurchasesPlugin extends Plugin {
 
-    private final String pluginVersion = "7.18.0";
+    private final String pluginVersion = "7.19.0";
     public static final String TAG = "NativePurchases";
     private static final Phaser semaphoreReady = new Phaser(1);
     private BillingClient billingClient;

--- a/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
+++ b/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
@@ -22,7 +22,7 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getStorefront", returnType: CAPPluginReturnPromise)
     ]
 
-    private let pluginVersion: String = "7.18.0"
+    private let pluginVersion: String = "7.19.0"
     private var transactionUpdatesTask: Task<Void, Never>?
 
     @objc func getPluginVersion(_ call: CAPPluginCall) {

--- a/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
+++ b/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
@@ -18,7 +18,8 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "acknowledgePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "consumePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getAppTransaction", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "isEntitledToOldBusinessModel", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "isEntitledToOldBusinessModel", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getStorefront", returnType: CAPPluginReturnPromise)
     ]
 
     private let pluginVersion: String = "7.18.0"
@@ -69,6 +70,25 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func isBillingSupported(_ call: CAPPluginCall) {
         call.resolve(["isBillingSupported": true])
+    }
+
+    @objc func getStorefront(_ call: CAPPluginCall) {
+        print("getStorefront")
+        Task {
+            let storefront = await Storefront.current
+            await MainActor.run {
+                if let storefront = storefront {
+                    call.resolve([
+                        "countryCode": storefront.countryCode,
+                        "storefrontId": storefront.id
+                    ])
+                } else {
+                    // No storefront (e.g. alternative distribution).
+                    print("getStorefront: no storefront available")
+                    call.resolve(["countryCode": ""])
+                }
+            }
+        }
     }
 
     @objc func purchaseProduct(_ call: CAPPluginCall) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capgo/native-purchases",
-  "version": "7.18.0",
+  "version": "7.19.0",
   "description": "In-app Subscriptions Made Easy",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1038,6 +1038,46 @@ export interface NativePurchasesPlugin {
   consumePurchase(options: { purchaseToken: string }): Promise<void>;
 
   /**
+   * Get the user's current App Store / Google Play storefront — the country
+   * their store account is registered to.
+   *
+   * iOS: reads StoreKit 2 `Storefront.current`. `countryCode` is ISO 3166-1
+   * **alpha-3** (e.g. `"USA"`) and `storefrontId` is the Apple-defined
+   * storefront identifier.
+   * Android: reads Google Play Billing `getBillingConfigAsync()`. `countryCode`
+   * is ISO 3166-1 **alpha-2** (e.g. `"US"`); `storefrontId` is omitted (Google
+   * Play has no storefront-id concept).
+   *
+   * Contract note (future-major default candidate): `countryCode` is returned in
+   * each store's native format and is intentionally NOT normalized across
+   * platforms today (iOS alpha-3 vs Android alpha-2), to stay faithful to the
+   * platform APIs. Normalizing both to a single scheme (e.g. ISO 3166-1 alpha-2)
+   * is a candidate default change for the next Capacitor major, deferred so it
+   * can be adopted deliberately rather than as a mid-major breaking change.
+   *
+   * Resolves a `countryCode` of `""` (it does not reject) when the storefront
+   * can't be determined on either platform — e.g. apps distributed via iOS
+   * alternative distribution, or Google Play billing being unavailable.
+   *
+   * Useful for region-dependent logic such as localized offers/pricing and
+   * gating external-purchase entitlements, whose eligibility the platforms key
+   * to the storefront country. Read it live rather than caching, since the user
+   * can change their store region.
+   *
+   * @returns {Promise<{ countryCode: string; storefrontId?: string }>} the current storefront
+   * @since 7.19.0
+   *
+   * @example
+   * ```typescript
+   * const { countryCode } = await NativePurchases.getStorefront();
+   * if (countryCode === 'USA' || countryCode === 'US') {
+   *   // show US-specific payment options
+   * }
+   * ```
+   */
+  getStorefront(): Promise<{ countryCode: string; storefrontId?: string }>;
+
+  /**
    * Listen for StoreKit transaction updates delivered by Apple's Transaction.updates.
    * Fires on app launch if there are unfinished transactions, and for any updates afterward.
    * iOS only.

--- a/src/web.ts
+++ b/src/web.ts
@@ -50,6 +50,11 @@ export class NativePurchasesWeb extends WebPlugin implements NativePurchasesPlug
     throw new Error('consumePurchase is only available on Android');
   }
 
+  async getStorefront(): Promise<{ countryCode: string; storefrontId?: string }> {
+    console.error('getStorefront only mocked in web');
+    return { countryCode: '' };
+  }
+
   async getAppTransaction(): Promise<{ appTransaction: AppTransaction }> {
     console.error('getAppTransaction only mocked in web');
     return {


### PR DESCRIPTION
## Summary
- Backports `getStorefront()` from the 8.x line (#190) onto the Capacitor 7 LTS branch (`lts-v7`).
- Adds CI auto-publish aligned with `capacitor-updater`: `bump_version` runs on `lts-v7` pushes, and `build.yml` publishes `7.x` tags under the `lts-v7` npm dist-tag.

## Status
- `lts-v7` branch is live and **7.19.0** is already published to npm as `@capgo/native-purchases@lts-v7`.
- Supersedes and closes #191 (fork PR targeting `v7`).

## Install
```bash
npm install @capgo/native-purchases@lts-v7
```

## Test plan
- [x] `bun run verify` passes locally (iOS, Android, web)
- [x] CI test workflow passed
- [x] `7.19.0` tag published to npm with `lts-v7` dist-tag