### PR TITLE
feat(ios): add presentOfferCodeRedeemSheet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1716,6 +1716,7 @@ This approach balances immediate user gratification with proper server-side vali
 * [`getPluginVersion()`](#getpluginversion)
 * [`getPurchases(...)`](#getpurchases)
 * [`manageSubscriptions()`](#managesubscriptions)
+* [`presentOfferCodeRedeemSheet()`](#presentoffercoderedeemsheet)
 * [`acknowledgePurchase(...)`](#acknowledgepurchase)
 * [`consumePurchase(...)`](#consumepurchase)
 * [`getStorefront()`](#getstorefront)
@@ -1917,6 +1918,21 @@ This allows users to view, modify, or cancel their subscriptions.
 - Android: Opens the Google Play subscription management page
 
 **Since:** 7.10.0
+
+--------------------
+
+
+### presentOfferCodeRedeemSheet()
+
+```typescript
+presentOfferCodeRedeemSheet() => Promise<void>
+```
+
+Presents the App Store offer code redemption sheet so users can redeem a subscription offer code in your app.
+
+iOS: Uses StoreKit's `AppStore.presentOfferCodeRedeemSheet(in:)` to display the system redemption UI (iOS 16.0+).
+
+**Since:** 8.6.0
 
 --------------------
 

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -1235,6 +1235,12 @@ public class NativePurchasesPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void presentOfferCodeRedeemSheet(PluginCall call) {
+        Log.d(TAG, "presentOfferCodeRedeemSheet() called");
+        call.reject("presentOfferCodeRedeemSheet is only available on iOS");
+    }
+
+    @PluginMethod
     public void acknowledgePurchase(PluginCall call) {
         Log.d(TAG, "acknowledgePurchase() called");
         String purchaseToken = call.getString("purchaseToken");

--- a/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
+++ b/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
@@ -15,6 +15,7 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPurchases", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "manageSubscriptions", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "presentOfferCodeRedeemSheet", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "acknowledgePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "consumePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getAppTransaction", returnType: CAPPluginReturnPromise),
@@ -232,6 +233,17 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    @objc func presentOfferCodeRedeemSheet(_ call: CAPPluginCall) {
+        print("presentOfferCodeRedeemSheet")
+        if #available(iOS 16.0, *) {
+            Task { @MainActor in
+                await self.handlePresentOfferCodeRedeemSheet(call)
+            }
+        } else {
+            call.reject("Offer code redemption requires iOS 16.0 or later")
+        }
+    }
+
     @objc func acknowledgePurchase(_ call: CAPPluginCall) {
         print("acknowledgePurchase called on iOS")
 
@@ -307,6 +319,23 @@ private extension NativePurchasesPlugin {
 
 // MARK: - iOS 16+ App Transaction Methods
 extension NativePurchasesPlugin {
+    @available(iOS 16.0, *)
+    @MainActor
+    private func handlePresentOfferCodeRedeemSheet(_ call: CAPPluginCall) async {
+        do {
+            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+                call.reject("Unable to get window scene")
+                return
+            }
+            try await AppStore.presentOfferCodeRedeemSheet(in: windowScene)
+            call.resolve()
+        } catch {
+            print("presentOfferCodeRedeemSheet error: \(error)")
+            call.reject(error.localizedDescription)
+        }
+    }
+
+
     @objc func getAppTransaction(_ call: CAPPluginCall) {
         if #available(iOS 16.0, *) {
             Task { @MainActor in

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1167,6 +1167,20 @@ export interface NativePurchasesPlugin {
   manageSubscriptions(): Promise<void>;
 
   /**
+   * Presents the App Store offer code redemption sheet so users can redeem a subscription offer code in your app.
+   *
+   * iOS: Uses StoreKit's `AppStore.presentOfferCodeRedeemSheet(in:)` to display the system redemption UI (iOS 16.0+).
+   *
+   * @returns {Promise<void>} Promise that resolves when the redemption sheet is presented
+   * @throws An error if the offer code redemption sheet cannot be presented
+   * @since 8.6.0
+   * @platform ios
+   *
+   * @see https://developer.apple.com/documentation/storekit/appstore/presentoffercoderedeemsheet(in:)
+   */
+  presentOfferCodeRedeemSheet(): Promise<void>;
+
+  /**
    * Manually acknowledge/finish a purchase transaction.
    *
    * This method is only needed when you set `autoAcknowledgePurchases: false` in purchaseProduct().

--- a/src/web.ts
+++ b/src/web.ts
@@ -54,6 +54,10 @@ export class NativePurchasesWeb extends WebPlugin implements NativePurchasesPlug
     console.error('manageSubscriptions only mocked in web');
   }
 
+  async presentOfferCodeRedeemSheet(): Promise<void> {
+    console.error('presentOfferCodeRedeemSheet only mocked in web');
+  }
+
   async acknowledgePurchase(options: { purchaseToken: string }): Promise<void> {
     void options;
     console.error('acknowledgePurchase only mocked in web');


### PR DESCRIPTION
## Summary
- Add `presentOfferCodeRedeemSheet()` to the TypeScript API with docgen-backed README docs (iOS 16.0+, StoreKit `AppStore.presentOfferCodeRedeemSheet(in:)`).
- Implement on iOS following the same window-scene flow as `manageSubscriptions`, with an availability guard for iOS 16+.
- Register the bridge method on iOS/Android (Android rejects) and add a web mock.

Closes #170

## Test plan
- [x] `bun run docgen`
- [x] `bun run verify` (iOS, Android, web)
- [ ] Manual: call `NativePurchases.presentOfferCodeRedeemSheet()` on iOS 16+ device/simulator and confirm the system redemption sheet appears


Made with [Cursor](https://cursor.com)