### PR TITLE
fix(deps): restore Capacitor 7 peer (>=7.0.0) on the lts-v7 line

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@capacitor/core": ">=8.0.0"
+    "@capacitor/core": ">=7.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",


### PR DESCRIPTION
## What
- On the `lts-v7` (Capacitor 7 LTS) line, restore the `@capacitor/core` peer dependency from `>=8.0.0` to `>=7.0.0`.

## Why
- `lts-v7` is the Capacitor 7 maintenance line, but its `@capacitor/core` peer is `>=8.0.0`, which **excludes Capacitor 7**. Cap-7 apps installing `@capgo/native-purchases@lts-v7` (7.19.0) therefore get a peer-dependency warning — and a hard failure under pnpm / `--strict-peer-deps` — even though the plugin is Capacitor-7 compatible and works fine at runtime.
- This looks like drift: `7.16.2` correctly declared `>=7.0.0`; it changed to `>=8.0.0` at `7.17.0`. This restores the correct floor for the 7.x line.

## How
- One-line change in `package.json` `peerDependencies`: `>=8.0.0` → `>=7.0.0`. `>=7.0.0` still admits both Capacitor 7 and 8.

## Testing
- Metadata-only peer-range change — no source/build impact. Verified the resulting value in `package.json`.

## Not Tested
- No install matrix / CI run in my environment.

## Notes
- Prepared with AI assistance (per AGENTS.md). Small follow-up alongside the `getStorefront()` backport that landed on `lts-v7` (7.19.0), noticed while documenting Capacitor-7 install requirements.
