### PR TITLE
chore: sync GitHub Actions setup with plugin template (lts-v7)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,7 @@ assignees: ''
 
 ### Capacitor Version
 <!--
-Paste the output from the `npx cap doctor` command into the code block below. This will provide the versions of Capacitor packages and related dependencies.
+Paste the output from the `bunx cap doctor` command into the code block below. This will provide the versions of Capacitor packages and related dependencies.
 -->
 
 ```
@@ -20,7 +20,7 @@ PASTE OUTPUT HERE
 
 ### Plugin Version
 <!--
-Paste the output from the `npx @capgo/cli@latest doctor` command into the code block below. This will provide the versions of Capacitor updater package.
+Paste the output from the `bunx @capgo/cli@latest doctor` command into the code block below. This will provide versions for the plugin package and related dependencies.
 -->
 ```
 PASTE OUTPUT HERE
@@ -71,7 +71,7 @@ For full instructions, see: https://github.com/ionic-team/capacitor/blob/HEAD/CO
 Please provide the following information with your request and any other relevant technical details (versions of IDEs, local environment info, plugin information or links, etc).
 -->
 
-`npm --version` output:
+`bun --version` output:
 
 `node --version` output:
 
@@ -81,4 +81,3 @@ Please provide the following information with your request and any other relevan
 <!--
 List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc.
 -->
-

--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+platform="${1:-}"
+case "$platform" in
+  android | ios | web) ;;
+  *)
+    echo "Usage: $0 <android|ios|web>"
+    exit 1
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_root="${RUNNER_TEMP:-$(mktemp -d)}"
+pack_dir="$tmp_root/plugin-package"
+test_app="$tmp_root/plugin-example-app"
+
+cd "$repo_root"
+
+bun run build
+
+rm -rf "$pack_dir" "$test_app"
+mkdir -p "$pack_dir" "$test_app"
+bun pm pack --destination "$pack_dir" --quiet
+
+shopt -s nullglob
+packed_packages=("$pack_dir"/*.tgz)
+shopt -u nullglob
+if [ "${#packed_packages[@]}" -ne 1 ]; then
+  echo "Expected exactly one package tarball, found ${#packed_packages[@]}"
+  exit 1
+fi
+
+plugin_name="$(bun -e 'console.log(require("./package.json").name)')"
+cp -R example-app/. "$test_app/"
+cd "$test_app"
+bun remove "$plugin_name"
+bun add "${packed_packages[0]}"
+bun run build
+
+case "$platform" in
+  android)
+    if [ ! -d android ]; then
+      bunx cap add android
+    fi
+    bunx cap sync android
+    cd android
+    ./gradlew build test
+    ;;
+  ios)
+    if [ ! -d ios ]; then
+      bunx cap add ios
+    fi
+    bunx cap sync ios
+    xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
+    ;;
+  web)
+    ;;
+esac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,40 +7,79 @@ concurrency:
 on:
   push:
     tags:
-      - "*"
+      - '*'
 
 jobs:
   # Tests already passed before tag was created, so just build and deploy
   deploy:
+    runs-on: ubuntu-latest
     # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
     timeout-minutes: 10
-    runs-on: ubuntu-latest
-    name: "Build code and npm release"
+    name: 'Build and publish to npm'
     permissions:
       contents: write
       id-token: write
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           filter: blob:none
-      - uses: oven-sh/setup-bun@v2
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2.2.0
       - name: Install dependencies
         id: install_code
         run: bun i
+      - name: Check plugin wiring
+        run: bun run check:wiring
       - name: Build
         id: build_code
         run: bun run build
+      - name: Detect previous tag
+        id: previous_tag
+        shell: bash
+        run: |
+          current_tag="${GITHUB_REF##*/}"
+          echo "current=$current_tag" >> "$GITHUB_OUTPUT"
+          if previous_tag=$(git describe --tags --abbrev=0 "${current_tag}^" 2>/dev/null); then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "value=$previous_tag" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Generate AI changelog
         id: changelog
+        if: ${{ steps.previous_tag.outputs.found == 'true' }}
         uses: mistricky/ccc@v0.2.6
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model: claude-sonnet-4-5-20250929
+      - name: Prepare release notes
+        id: release_notes
+        shell: bash
+        env:
+          CURRENT_TAG: ${{ steps.previous_tag.outputs.current }}
+          PREVIOUS_TAG: ${{ steps.previous_tag.outputs.value }}
+          CHANGELOG_TEXT: ${{ steps.changelog.outputs.result }}
+        run: |
+          if [[ "${{ steps.previous_tag.outputs.found }}" == "true" ]]; then
+            {
+              printf '## 🆕 Changelog\n\n'
+              printf '%s\n\n' "$CHANGELOG_TEXT"
+              printf '%s\n\n' '---'
+              printf '🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/%s...%s\n' "$PREVIOUS_TAG" "$CURRENT_TAG"
+            } > release-notes.md
+          else
+            {
+              printf '## 🆕 Changelog\n\n'
+              printf 'Initial release.\n\n'
+              printf '%s\n\n' '---'
+              printf '🔖 **Tag**: %s\n' "$CURRENT_TAG"
+            } > release-notes.md
+          fi
       - name: Setup Node.js for npm publish
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
@@ -53,7 +92,7 @@ jobs:
         if: ${{ !contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/7.') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag latest --provenance --access public
+        run: npm publish --provenance --access public
       - name: Publish to npm with next tag
         if: ${{ contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/7.') }}
         env:
@@ -61,16 +100,9 @@ jobs:
         run: npm publish --tag next --provenance --access public
       - name: Create GitHub release
         id: create_release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v3.0.0
         with:
-          body: |
-            ## 🆕 Changelog
-
-            ${{ steps.changelog.outputs.result }}
-
-            ---
-
-            🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag }}...${{ steps.changelog.outputs.to_tag }}
+          body_path: release-notes.md
           make_latest: ${{ !contains(github.ref, '-alpha.') && !startsWith(github.ref, 'refs/tags/7.') }}
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
           prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -25,19 +25,20 @@ jobs:
     runs-on: ubuntu-latest
     # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
     timeout-minutes: 10
-    name: "Bump version and create tag"
+    name: 'Bump version and create tag'
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24.x
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           filter: blob:none
+          persist-credentials: false
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.2.0
       - name: Install dependencies
         id: install_code
         run: bun i

--- a/.github/workflows/deploy_example_app.yml
+++ b/.github/workflows/deploy_example_app.yml
@@ -40,6 +40,6 @@ jobs:
 
       - name: Deploy to Capgo
         working-directory: example-app
-        run: bunx @capgo/cli@latest bundle upload app.capgo.native.purchases --path dist --channel production --package-json package.json,../package.json --node-modules node_modules,../node_modules --delta --no-key --ignore-checksum-check --version-exists-ok --apikey "$CAPGO_TOKEN"
+        run: bunx @capgo/cli@latest bundle upload app.capgo.nativepurchases --path dist --channel production --package-json package.json,../package.json --node-modules node_modules,../node_modules --delta --no-key --ignore-checksum-check --version-exists-ok --apikey "$CAPGO_TOKEN"
         env:
           CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}

--- a/.github/workflows/deploy_example_app.yml
+++ b/.github/workflows/deploy_example_app.yml
@@ -1,0 +1,45 @@
+name: Deploy example app to Capgo
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: ${{ github.event_name != 'release' || !github.event.release.prerelease }}
+    name: Deploy example app to Capgo
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+          fetch-depth: 1
+          filter: blob:none
+          persist-credentials: false
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.11
+          no-cache: true
+
+      - name: Install plugin dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build example app
+        run: bun run example:build
+
+      - name: Deploy to Capgo
+        working-directory: example-app
+        run: bunx @capgo/cli@latest bundle upload app.capgo.native.purchases --path dist --channel production --package-json package.json,../package.json --node-modules node_modules,../node_modules --delta --no-key --ignore-checksum-check --version-exists-ok --apikey "$CAPGO_TOKEN"
+        env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}

--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -6,16 +6,22 @@ on:
 
 jobs:
   github-releases-to-discord:
-    timeout-minutes: 30
     runs-on: ubuntu-latest
+    # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
+    timeout-minutes: 10
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24.x
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
       - name: GitHub Releases to Discord
-        uses: SethCohen/github-releases-to-discord@v1
+        uses: SethCohen/github-releases-to-discord@v1.20.0
         with:
           webhook_url: ${{ secrets.WEBHOOK_DISCORD_RELEASE_URL }}
-          color: "2105893"
-          username: "Release @${{ github.repository }}"
-          avatar_url: "https://cdn.discordapp.com/avatars/487431320314576937/bd64361e4ba6313d561d54e78c9e7171.png"
+          color: '2105893'
+          footer_title: 'Release @${{ github.repository }}'
           reduce_headings: true

--- a/.github/workflows/pr_beta_prompt.yml
+++ b/.github/workflows/pr_beta_prompt.yml
@@ -1,0 +1,86 @@
+name: PR beta publish prompt
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
+    timeout-minutes: 10
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24.x
+      - name: Upsert beta publish comment
+        uses: actions/github-script@v9.0.0
+        env:
+          IS_SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
+        with:
+          script: |
+            const marker = '<!-- pr-beta-publish -->';
+            const sameRepo = process.env.IS_SAME_REPO === 'true';
+            const pr = context.payload.pull_request;
+            const body = sameRepo
+              ? [
+                  marker,
+                  '',
+                  '## Beta npm build',
+                  '',
+                  'Maintainers can publish this PR to npm for fast testing.',
+                  '',
+                  'Comment `/publish-beta` after the PR checks are green.',
+                  '',
+                  'The workflow will:',
+                  '- publish a prerelease package on the `beta` tag',
+                  `- add a pinned \`pr-${pr.number}\` dist-tag for this exact PR build`,
+                  '- update this comment with the install command',
+                  '',
+                  'Security note: beta publish is only enabled for branches inside this repository.',
+                ].join('\n')
+              : [
+                  marker,
+                  '',
+                  '## Beta npm build',
+                  '',
+                  'This PR comes from a fork, so beta publish is disabled for security.',
+                  '',
+                  'If you need a beta package, move the branch into this repository first.',
+                ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.user.type === 'Bot' && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr.number,
+              body,
+            });

--- a/.github/workflows/pr_beta_publish.yml
+++ b/.github/workflows/pr_beta_publish.yml
@@ -1,0 +1,317 @@
+name: Publish PR beta package
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to publish
+        required: true
+        type: number
+
+concurrency:
+  group: pr-beta-${{ github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.issue.pull_request && contains(github.event.comment.body, '/publish-beta')) }}
+    runs-on: ubuntu-latest
+    # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
+    timeout-minutes: 10
+    steps:
+      - name: Resolve PR and access checks
+        id: pr
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const prNumber = context.eventName === 'workflow_dispatch'
+              ? Number(core.getInput('pr_number'))
+              : context.payload.issue.number;
+
+            const { owner, repo } = context.repo;
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const actor = context.eventName === 'issue_comment'
+              ? context.payload.comment.user.login
+              : context.actor;
+
+            core.setOutput('actor', actor);
+            core.setOutput('pr_number', String(prNumber));
+
+            if (pr.state !== 'open') {
+              core.setFailed(`PR #${prNumber} is not open.`);
+              return;
+            }
+
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.setFailed('Fork PRs cannot publish beta packages because the workflow needs repository secrets.');
+              return;
+            }
+
+            if (context.eventName === 'issue_comment') {
+              const actor = context.payload.comment.user.login;
+              const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: actor,
+              });
+              const allowed = ['admin', 'maintain', 'write'].includes(permission.permission);
+
+              if (!allowed) {
+                core.setFailed(`@${actor} does not have permission to publish beta packages.`);
+                return;
+              }
+            }
+
+            const prState = await github.graphql(
+              `query($owner: String!, $repo: String!, $prNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $prNumber) {
+                    commits(last: 1) {
+                      nodes {
+                        commit {
+                          statusCheckRollup {
+                            state
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`,
+              {
+                owner,
+                repo,
+                prNumber,
+              },
+            );
+
+            const rollupState = prState.repository.pullRequest.commits.nodes[0]?.commit.statusCheckRollup?.state ?? 'PENDING';
+
+            if (rollupState !== 'SUCCESS') {
+              core.setFailed(`PR checks are not green yet (current state: ${rollupState}).`);
+              return;
+            }
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Mark publish as running
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const marker = '<!-- pr-beta-publish -->';
+            const prNumber = Number('${{ steps.pr.outputs.pr_number }}');
+            const actor = '${{ steps.pr.outputs.actor }}';
+            const body = [
+              marker,
+              '',
+              '## Beta npm build',
+              '',
+              'Status: publishing',
+              '',
+              `Requested by @${actor}.`,
+              '',
+              `This run will publish the PR head to the \`beta\` npm tag and refresh \`pr-${prNumber}\`.`,
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.user.type === 'Bot' && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+      - name: Check out PR head
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2.2.0
+
+      - name: Install dependencies
+        run: bun i
+
+      - name: Check plugin wiring
+        run: bun run check:wiring
+
+      - name: Set beta package version
+        id: version
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('fs');
+          const path = 'package.json';
+          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          const baseVersion = pkg.version.split('-')[0];
+          const prNumber = process.env.PR_NUMBER;
+          const runNumber = process.env.GITHUB_RUN_NUMBER;
+          const runAttempt = process.env.GITHUB_RUN_ATTEMPT;
+          const betaVersion = `${baseVersion}-beta.pr${prNumber}.${runNumber}.${runAttempt}`;
+
+          pkg.version = betaVersion;
+          fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\n`);
+
+          console.log(`package_name=${pkg.name}`);
+          console.log(`version=${betaVersion}`);
+          NODE
+
+      - name: Build
+        run: bun run build
+
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm beta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag beta --provenance --access public --ignore-scripts
+
+      - name: Add PR dist-tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm dist-tag add "${{ steps.version.outputs.package_name }}@${{ steps.version.outputs.version }}" "pr-${{ steps.pr.outputs.pr_number }}"
+
+      - name: Publish success comment
+        if: ${{ success() }}
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const marker = '<!-- pr-beta-publish -->';
+            const prNumber = Number('${{ steps.pr.outputs.pr_number }}');
+            const actor = '${{ steps.pr.outputs.actor }}';
+            const packageName = '${{ steps.version.outputs.package_name }}';
+            const version = '${{ steps.version.outputs.version }}';
+            const shortSha = '${{ steps.pr.outputs.head_sha }}'.slice(0, 7);
+            const body = [
+              marker,
+              '',
+              '## Beta npm build',
+              '',
+              'Status: published',
+              '',
+              `Version: \`${version}\``,
+              `Source: \`${shortSha}\``,
+              `Requested by @${actor}`,
+              '',
+              'Latest beta:',
+              '```sh',
+              `bun add ${packageName}@beta`,
+              '```',
+              '',
+              'This PR only:',
+              '```sh',
+              `bun add ${packageName}@pr-${prNumber}`,
+              '```',
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.user.type === 'Bot' && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+      - name: Publish failure comment
+        if: ${{ failure() && steps.pr.outputs.pr_number != '' }}
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const marker = '<!-- pr-beta-publish -->';
+            const prNumber = Number('${{ steps.pr.outputs.pr_number }}');
+            const body = [
+              marker,
+              '',
+              '## Beta npm build',
+              '',
+              'Status: failed',
+              '',
+              'Open the run for details:',
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.user.type === 'Bot' && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,22 @@ on:
       - renovate/**
   pull_request:
     branches: [main, lts-v7]
-  workflow_dispatch:
-  workflow_call:  # Allow this workflow to be called by other workflows
+  workflow_call: # Allow this workflow to be called by other workflows
 
 jobs:
   guard_swiftpm_version:
-    timeout-minutes: 30
     runs-on: ubuntu-latest
+    # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
+    timeout-minutes: 10
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24.x
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
       - name: Enforce capacitor-swift-pm version
         run: |
           set -euo pipefail
@@ -24,53 +30,86 @@ jobs:
             exit 1
           fi
   build_android:
-    timeout-minutes: 30
     runs-on: ubuntu-latest
+    # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
+    timeout-minutes: 10
     steps:
       - name: Check out
-        uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2.2.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24.x
       - name: Install dependencies
         id: install_code
         run: bun i
+      - name: Check plugin wiring
+        run: bun run check:wiring
       - name: Setup java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Build
         id: build_code
-        run: npm run verify:android
+        run: bun run verify:android
+      - name: Verify packed package in example app (Android)
+        shell: bash
+        run: bash ./.github/scripts/verify-packed-example.sh android
   build_ios:
-    timeout-minutes: 30
     runs-on: macOS-latest
+    # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
+    timeout-minutes: 10
     steps:
       - name: Check out
-        uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2.2.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24.x
       - name: Install dependencies
         id: install_code
         run: bun i
+      - name: Check plugin wiring
+        run: bun run check:wiring
       - name: Build
         id: build_code
         run: bun run verify:ios
+      - name: Verify packed package in example app (iOS)
+        shell: bash
+        run: bash ./.github/scripts/verify-packed-example.sh ios
   web:
-    timeout-minutes: 30
     runs-on: ubuntu-latest
+    # Keep this job capped at 10 minutes; never raise it unless explicitly asked.
+    timeout-minutes: 10
     name: 'Build code and test'
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24.x
       - name: Check out
-        uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2.2.0
       - name: Install dependencies
         id: install_code
         run: bun i
+      - name: Check plugin wiring
+        run: bun run check:wiring
       - name: Lint
         id: lint_code
         run: bun run lint
-      - name: Build
-        id: build_code
-        run: bun run build
+      - name: Verify packed package in example app (Web)
+        shell: bash
+        run: bash ./.github/scripts/verify-packed-example.sh web
       - name: Verify
         id: verify_code
         run: bun run verify:web

--- a/example-app/android/app/build.gradle
+++ b/example-app/android/app/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace = "app.capgo.native.purchases"
+    namespace = "app.capgo.nativepurchases"
     compileSdk = rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId = "app.capgo.native.purchases"
+        applicationId = "app.capgo.nativepurchases"
         minSdkVersion = rootProject.ext.minSdkVersion
         targetSdkVersion = rootProject.ext.targetSdkVersion
         versionCode = 1

--- a/example-app/android/app/src/main/java/app/capgo/nativepurchases/MainActivity.java
+++ b/example-app/android/app/src/main/java/app/capgo/nativepurchases/MainActivity.java
@@ -1,4 +1,4 @@
-package app.capgo.native.purchases;
+package app.capgo.nativepurchases;
 
 import com.getcapacitor.BridgeActivity;
 

--- a/example-app/android/app/src/main/res/values/strings.xml
+++ b/example-app/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
 <resources>
     <string name="app_name">Native Purchases Example</string>
     <string name="title_activity_main">Native Purchases Example</string>
-    <string name="package_name">app.capgo.native.purchases</string>
-    <string name="custom_url_scheme">app.capgo.native.purchases</string>
+    <string name="package_name">app.capgo.nativepurchases</string>
+    <string name="custom_url_scheme">app.capgo.nativepurchases</string>
 </resources>

--- a/example-app/capacitor.config.json
+++ b/example-app/capacitor.config.json
@@ -1,5 +1,5 @@
 {
-  "appId": "app.capgo.native.purchases",
+  "appId": "app.capgo.nativepurchases",
   "appName": "Native Purchases Example",
   "webDir": "dist",
   "plugins": {

--- a/example-app/ios/App/App.xcodeproj/project.pbxproj
+++ b/example-app/ios/App/App.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
-				PRODUCT_BUNDLE_IDENTIFIER = app.capgo.native.purchases;
+				PRODUCT_BUNDLE_IDENTIFIER = app.capgo.nativepurchases;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
@@ -326,7 +326,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = app.capgo.native.purchases;
+				PRODUCT_BUNDLE_IDENTIFIER = app.capgo.nativepurchases;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "docgen": "docgen --api NativePurchasesPlugin --output-readme README.md --output-json dist/docs.json",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs",
+    "example:install": "cd example-app && bun install --frozen-lockfile",
+    "example:build": "bun run build && cd example-app && bun install --frozen-lockfile && bun run build"
   },
   "devDependencies": {
     "@capacitor/android": "^8.0.0",

--- a/scripts/check-capacitor-plugin-wiring.mjs
+++ b/scripts/check-capacitor-plugin-wiring.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * Capacitor plugin wiring/name checker.
+ *
+ * Enforces that runtime plugin name matches across:
+ * - JS: registerPlugin('Name')
+ * - Android: @CapacitorPlugin(name = "Name")
+ * - iOS: CAPBridgedPlugin jsName = "Name"
+ *
+ * And (when iOS is declared in package.json capacitor config):
+ * - CocoaPods podspec s.name matches SwiftPM Package(name: ...) and .library(name: ...)
+ *
+ * Usage:
+ *   node scripts/check-capacitor-plugin-wiring.mjs            # checks current working dir
+ *   node scripts/check-capacitor-plugin-wiring.mjs --dir path # checks given plugin dir
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".build",
+  ".gradle",
+  "Pods",
+  "DerivedData",
+  ".swiftpm",
+  ".git",
+]);
+
+function readText(p) {
+  try {
+    return fs.readFileSync(p, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function exists(p) {
+  try {
+    fs.accessSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function walkFiles(rootDir, exts) {
+  const out = [];
+  const stack = [rootDir];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (SKIP_DIRS.has(e.name)) continue;
+        stack.push(path.join(dir, e.name));
+        continue;
+      }
+      if (!e.isFile()) continue;
+      for (const ext of exts) {
+        if (e.name.endsWith(ext)) {
+          out.push(path.join(dir, e.name));
+          break;
+        }
+      }
+    }
+  }
+  out.sort();
+  return out;
+}
+
+function uniq(arr) {
+  const out = [];
+  for (const x of arr) {
+    if (!x) continue;
+    if (!out.includes(x)) out.push(x);
+  }
+  return out;
+}
+
+function parseArgs(argv) {
+  const out = { dir: process.cwd() };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dir" || a === "--pluginDir") {
+      out.dir = path.resolve(argv[++i] || ".");
+      continue;
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+const pluginDir = args.dir;
+const pkgPath = path.join(pluginDir, "package.json");
+
+if (!exists(pkgPath)) {
+  console.error(`[wiring] ERROR: missing package.json in ${pluginDir}`);
+  process.exit(2);
+}
+
+let pkg;
+try {
+  pkg = JSON.parse(readText(pkgPath));
+} catch (e) {
+  console.error(`[wiring] ERROR: invalid package.json (${pkgPath}): ${e?.message || e}`);
+  process.exit(2);
+}
+
+const cap = typeof pkg.capacitor === "object" && pkg.capacitor ? pkg.capacitor : {};
+const supportsAndroid = typeof cap.android === "object" && cap.android;
+const supportsIos = typeof cap.ios === "object" && cap.ios;
+
+// Not a Capacitor plugin package (e.g. meta/workspace package).
+// We only enforce wiring rules for actual plugin packages declaring a `capacitor` config.
+if (!supportsAndroid && !supportsIos) {
+  process.exit(0);
+}
+
+// ---------------- JS (registerPlugin) ----------------
+const jsSrcDir = path.join(pluginDir, "src");
+let jsName = "";
+if (exists(jsSrcDir)) {
+  const jsFiles = walkFiles(jsSrcDir, [".ts", ".js"]);
+  const reRegister = /registerPlugin(?:<[^>]*>)?\(\s*['"]([^'"]+)['"]/;
+  for (const f of jsFiles) {
+    const m = reRegister.exec(readText(f));
+    if (m) {
+      jsName = m[1];
+      break;
+    }
+  }
+}
+
+// ---------------- Android (@CapacitorPlugin) ----------------
+let androidNames = [];
+if (supportsAndroid) {
+  const androidMain = path.join(pluginDir, "android", "src", "main");
+  const files = walkFiles(androidMain, [".java", ".kt"]);
+  const foundAnnotations = [];
+  for (const f of files) {
+    const txt = readText(f);
+    if (!txt.includes("@CapacitorPlugin")) continue;
+    foundAnnotations.push(f);
+    const m =
+      /@CapacitorPlugin\(\s*name\s*=\s*"([^"]+)"/.exec(txt) ||
+      /@CapacitorPlugin\(\s*name\s*=\s*([A-Za-z0-9_]+)\b/.exec(txt);
+    if (m) androidNames.push(m[1]);
+  }
+  androidNames = uniq(androidNames);
+
+  // Enforce explicit name attribute to prevent silent class-name drift.
+  if (foundAnnotations.length && !androidNames.length) {
+    console.error(
+      `[wiring] ERROR: Android has @CapacitorPlugin but none specify name = \"...\". Add an explicit name to the plugin class.`
+    );
+    process.exit(1);
+  }
+}
+
+// ---------------- iOS (jsName) ----------------
+let iosJsNames = [];
+if (supportsIos) {
+  const iosDir = path.join(pluginDir, "ios");
+  const scanRoot = exists(path.join(iosDir, "Sources")) ? path.join(iosDir, "Sources") : iosDir;
+  const swiftFiles = walkFiles(scanRoot, [".swift"]);
+  const reJsName = /\bjsName\s*=\s*"([^"]+)"/g;
+  for (const f of swiftFiles) {
+    const txt = readText(f);
+    if (!txt.includes("jsName")) continue;
+    let m;
+    while ((m = reJsName.exec(txt))) iosJsNames.push(m[1]);
+  }
+  iosJsNames = uniq(iosJsNames);
+}
+
+// ---------------- Podspec/SPM ----------------
+function parsePodspecName(podspecPath) {
+  const txt = readText(podspecPath);
+  const m = /\bs\.name\s*=\s*'([^']+)'/.exec(txt);
+  return m ? m[1] : "";
+}
+
+function parseSpmNames(packageSwiftPath) {
+  const txt = readText(packageSwiftPath);
+  const pkg = /Package\(\s*name\s*:\s*"([^"]+)"/.exec(txt)?.[1] || "";
+  const libs = [];
+  const reLib = /\.library\(\s*name\s*:\s*"([^"]+)"/g;
+  let m;
+  while ((m = reLib.exec(txt))) libs.push(m[1]);
+  return { pkgName: pkg, libNames: uniq(libs) };
+}
+
+// ---------------- Validate ----------------
+const errors = [];
+
+if (!jsName) {
+  errors.push("JS: no registerPlugin('...') found under src/");
+}
+
+if (supportsAndroid) {
+  if (!androidNames.length) errors.push("Android: missing @CapacitorPlugin(name = \"...\")");
+  if (jsName && androidNames.length && androidNames.some((n) => n !== jsName)) {
+    errors.push(`Android: @CapacitorPlugin(name)=${JSON.stringify(androidNames)} != JS registerPlugin=${jsName}`);
+  }
+}
+
+if (supportsIos) {
+  if (!iosJsNames.length) errors.push('iOS: missing jsName = "..." in Swift sources');
+  if (jsName && iosJsNames.length && iosJsNames.some((n) => n !== jsName)) {
+    errors.push(`iOS: jsName=${JSON.stringify(iosJsNames)} != JS registerPlugin=${jsName}`);
+  }
+
+  const podspecs = fs
+    .readdirSync(pluginDir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith(".podspec"))
+    .map((e) => path.join(pluginDir, e.name))
+    .sort();
+  if (!podspecs.length) errors.push("iOS: missing *.podspec at plugin root");
+  if (podspecs.length > 1) errors.push(`iOS: multiple podspecs at plugin root: ${podspecs.map((p) => path.basename(p))}`);
+
+  const pkgSwift = path.join(pluginDir, "Package.swift");
+  if (!exists(pkgSwift)) {
+    errors.push("iOS: missing Package.swift at plugin root");
+  } else if (podspecs.length) {
+    const podName = parsePodspecName(podspecs[0]);
+    const { pkgName, libNames } = parseSpmNames(pkgSwift);
+    if (!podName) errors.push("Podspec: missing s.name = '...'");
+    if (!pkgName) errors.push('SPM: missing Package(name: "...")');
+    if (podName && pkgName && podName !== pkgName) {
+      errors.push(`Podspec: s.name=${podName} != Package(name)=${pkgName}`);
+    }
+    if (pkgName && libNames.length && !libNames.includes(pkgName)) {
+      errors.push(`SPM: Package(name)=${pkgName} not present in .library(name) list ${JSON.stringify(libNames)}`);
+    }
+  }
+}
+
+if (errors.length) {
+  const relDir = path.relative(process.cwd(), pluginDir) || ".";
+  console.error(`[wiring] FAIL in ${relDir}`);
+  for (const e of errors) console.error(`- ${e}`);
+  process.exit(1);
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- Sync `.github/` workflows, scripts, and issue templates with the canonical `capacitor-plugin-template` setup on the `lts-v7` branch
- Add missing CI pieces: `verify-packed-example.sh`, `check:wiring`, `example:build`, beta publish workflows, and Capgo deploy workflow
- Preserve lts-v7-specific release behavior (`npm publish --tag lts-v7`, lts-v7 bump-version branch, PR triggers on `lts-v7`)

## Test plan
- [ ] CI `Build source code and test it` passes on this PR
- [ ] Android, iOS, and web jobs complete successfully
- [ ] Verify packed example app steps pass


Made with [Cursor](https://cursor.com)