### PR TITLE
fix(android): prevent BillingClient setup from blocking Capacitor bridge

### DIFF
--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -50,7 +50,7 @@ public class NativePurchasesPlugin extends Plugin {
     private static final long BILLING_SETUP_TIMEOUT_SECONDS = 5;
     private static final long[] BILLING_CONNECTION_BACKOFF_MS = { 0, 1000 };
     private final Object billingClientLock = new Object();
-    private final ExecutorService billingExecutor = Executors.newSingleThreadExecutor(r -> {
+    private final ExecutorService billingExecutor = Executors.newSingleThreadExecutor((r) -> {
         Thread thread = new Thread(r, "NativePurchases-Billing");
         thread.setDaemon(true);
         return thread;
@@ -110,7 +110,10 @@ public class NativePurchasesPlugin extends Plugin {
                             } else {
                                 Log.e(
                                     TAG,
-                                    "getBillingConfig unavailable: " + billingResult.getResponseCode() + " - " + billingResult.getDebugMessage()
+                                    "getBillingConfig unavailable: " +
+                                        billingResult.getResponseCode() +
+                                        " - " +
+                                        billingResult.getDebugMessage()
                                 );
                                 ret.put("countryCode", "");
                             }
@@ -1063,21 +1066,21 @@ public class NativePurchasesPlugin extends Plugin {
         }
 
         withBillingClient(call, () -> {
-        JSONArray allPurchases = new JSONArray();
-        AtomicInteger pendingQueries = new AtomicInteger((queryInApp ? 1 : 0) + (querySubs ? 1 : 0));
-        AtomicBoolean finished = new AtomicBoolean(false);
+            JSONArray allPurchases = new JSONArray();
+            AtomicInteger pendingQueries = new AtomicInteger((queryInApp ? 1 : 0) + (querySubs ? 1 : 0));
+            AtomicBoolean finished = new AtomicBoolean(false);
 
-        Runnable maybeFinish = () -> {
-            int remaining = pendingQueries.decrementAndGet();
-            Log.d(TAG, "Pending purchase queries remaining: " + remaining);
-            if (remaining <= 0 && finished.compareAndSet(false, true)) {
-                JSObject result = new JSObject();
-                result.put("purchases", allPurchases);
-                Log.d(TAG, "Returning " + allPurchases.length() + " purchases");
-                closeBillingClient();
-                call.resolve(result);
-            }
-        };
+            Runnable maybeFinish = () -> {
+                int remaining = pendingQueries.decrementAndGet();
+                Log.d(TAG, "Pending purchase queries remaining: " + remaining);
+                if (remaining <= 0 && finished.compareAndSet(false, true)) {
+                    JSObject result = new JSObject();
+                    result.put("purchases", allPurchases);
+                    Log.d(TAG, "Returning " + allPurchases.length() + " purchases");
+                    closeBillingClient();
+                    call.resolve(result);
+                }
+            };
 
             if (queryInApp) {
                 Log.d(TAG, "Querying in-app purchases");

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,86 +46,89 @@ public class NativePurchasesPlugin extends Plugin {
 
     private final String pluginVersion = "8.6.1";
     public static final String TAG = "NativePurchases";
-    private static final int BILLING_CONNECTION_MAX_ATTEMPTS = 3;
-    private static final long BILLING_SETUP_TIMEOUT_SECONDS = 10;
-    private static final long[] BILLING_CONNECTION_BACKOFF_MS = { 0, 1000, 2000 };
+    private static final int BILLING_CONNECTION_MAX_ATTEMPTS = 2;
+    private static final long BILLING_SETUP_TIMEOUT_SECONDS = 5;
+    private static final long[] BILLING_CONNECTION_BACKOFF_MS = { 0, 1000 };
     private final Object billingClientLock = new Object();
+    private final ExecutorService billingExecutor = Executors.newSingleThreadExecutor(r -> {
+        Thread thread = new Thread(r, "NativePurchases-Billing");
+        thread.setDaemon(true);
+        return thread;
+    });
     private BillingClient billingClient;
 
     @PluginMethod
     public void isBillingSupported(PluginCall call) {
         Log.d(TAG, "isBillingSupported() called");
-        try {
-            // Try to initialize billing client to check if billing is actually available
-            // Pass null so initBillingClient doesn't reject the call - we'll handle the result ourselves
-            this.initBillingClient(null);
-            // If initialization succeeded, billing is supported
-            JSObject ret = new JSObject();
-            ret.put("isBillingSupported", true);
-            Log.d(TAG, "isBillingSupported() returning true - billing client initialized successfully");
-            closeBillingClient();
-            call.resolve(ret);
-        } catch (RuntimeException e) {
-            Log.e(TAG, "isBillingSupported() - billing client initialization failed: " + e.getMessage());
-            closeBillingClient();
-            // Return false instead of rejecting - this is a check method
-            JSObject ret = new JSObject();
-            ret.put("isBillingSupported", false);
-            Log.d(TAG, "isBillingSupported() returning false - billing not available");
-            call.resolve(ret);
-        } catch (Exception e) {
-            Log.e(TAG, "isBillingSupported() - unexpected error: " + e.getMessage());
-            closeBillingClient();
-            JSObject ret = new JSObject();
-            ret.put("isBillingSupported", false);
-            Log.d(TAG, "isBillingSupported() returning false - unexpected error");
-            call.resolve(ret);
-        }
+        billingExecutor.execute(() -> {
+            try {
+                // Pass null so initBillingClient doesn't reject the call - we'll handle the result ourselves
+                this.initBillingClient(null);
+                JSObject ret = new JSObject();
+                ret.put("isBillingSupported", true);
+                Log.d(TAG, "isBillingSupported() returning true - billing client initialized successfully");
+                closeBillingClient();
+                call.resolve(ret);
+            } catch (RuntimeException e) {
+                Log.e(TAG, "isBillingSupported() - billing client initialization failed: " + e.getMessage());
+                closeBillingClient();
+                JSObject ret = new JSObject();
+                ret.put("isBillingSupported", false);
+                Log.d(TAG, "isBillingSupported() returning false - billing not available");
+                call.resolve(ret);
+            } catch (Exception e) {
+                Log.e(TAG, "isBillingSupported() - unexpected error: " + e.getMessage());
+                closeBillingClient();
+                JSObject ret = new JSObject();
+                ret.put("isBillingSupported", false);
+                Log.d(TAG, "isBillingSupported() returning false - unexpected error");
+                call.resolve(ret);
+            }
+        });
     }
 
     @PluginMethod
     public void getStorefront(PluginCall call) {
         Log.d(TAG, "getStorefront() called");
-        try {
-            // Pass null so initBillingClient doesn't reject the call - getStorefront
-            // always resolves and reports an empty countryCode when the storefront
-            // can't be determined, mirroring isBillingSupported() and the iOS side.
-            this.initBillingClient(null);
-        } catch (RuntimeException e) {
-            Log.e(TAG, "getStorefront() - billing client init failed: " + e.getMessage());
-            closeBillingClient();
-            call.resolve(emptyStorefront());
-            return;
-        }
-        try {
-            billingClient.getBillingConfigAsync(
-                GetBillingConfigParams.newBuilder().build(),
-                new BillingConfigResponseListener() {
-                    @Override
-                    public void onBillingConfigResponse(@NonNull BillingResult billingResult, BillingConfig billingConfig) {
-                        JSObject ret = new JSObject();
-                        if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK && billingConfig != null) {
-                            String countryCode = billingConfig.getCountryCode();
-                            Log.d(TAG, "getBillingConfig success, countryCode: " + countryCode);
-                            // JSObject.put(name, null) removes the key, so coalesce to "".
-                            ret.put("countryCode", countryCode != null ? countryCode : "");
-                        } else {
-                            Log.e(
-                                TAG,
-                                "getBillingConfig unavailable: " + billingResult.getResponseCode() + " - " + billingResult.getDebugMessage()
-                            );
-                            ret.put("countryCode", "");
+        billingExecutor.execute(() -> {
+            try {
+                // Pass null so initBillingClient doesn't reject the call - getStorefront
+                // always resolves and reports an empty countryCode when the storefront
+                // can't be determined, mirroring isBillingSupported() and the iOS side.
+                this.initBillingClient(null);
+                billingClient.getBillingConfigAsync(
+                    GetBillingConfigParams.newBuilder().build(),
+                    new BillingConfigResponseListener() {
+                        @Override
+                        public void onBillingConfigResponse(@NonNull BillingResult billingResult, BillingConfig billingConfig) {
+                            JSObject ret = new JSObject();
+                            if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK && billingConfig != null) {
+                                String countryCode = billingConfig.getCountryCode();
+                                Log.d(TAG, "getBillingConfig success, countryCode: " + countryCode);
+                                // JSObject.put(name, null) removes the key, so coalesce to "".
+                                ret.put("countryCode", countryCode != null ? countryCode : "");
+                            } else {
+                                Log.e(
+                                    TAG,
+                                    "getBillingConfig unavailable: " + billingResult.getResponseCode() + " - " + billingResult.getDebugMessage()
+                                );
+                                ret.put("countryCode", "");
+                            }
+                            closeBillingClient();
+                            call.resolve(ret);
                         }
-                        closeBillingClient();
-                        call.resolve(ret);
                     }
-                }
-            );
-        } catch (Exception e) {
-            Log.e(TAG, "getBillingConfigAsync threw: " + e.getMessage());
-            closeBillingClient();
-            call.resolve(emptyStorefront());
-        }
+                );
+            } catch (RuntimeException e) {
+                Log.e(TAG, "getStorefront() - billing client init failed: " + e.getMessage());
+                closeBillingClient();
+                call.resolve(emptyStorefront());
+            } catch (Exception e) {
+                Log.e(TAG, "getBillingConfigAsync threw: " + e.getMessage());
+                closeBillingClient();
+                call.resolve(emptyStorefront());
+            }
+        });
     }
 
     private JSObject emptyStorefront() {
@@ -138,6 +143,36 @@ public class NativePurchasesPlugin extends Plugin {
         Log.d(TAG, "Plugin load() called");
         Log.i(NativePurchasesPlugin.TAG, "load");
         Log.d(TAG, "Plugin load() completed");
+    }
+
+    @FunctionalInterface
+    private interface BillingTask {
+        void run() throws Exception;
+    }
+
+    private void withBillingClient(PluginCall call, BillingTask task) {
+        billingExecutor.execute(() -> {
+            try {
+                initBillingClient(call);
+                task.run();
+            } catch (RuntimeException e) {
+                Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
+                closeBillingClient();
+            } catch (Exception e) {
+                Log.e(TAG, "Billing task failed: " + e.getMessage());
+                closeBillingClient();
+                if (call != null) {
+                    call.reject(e.getMessage());
+                }
+            }
+        });
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        billingExecutor.shutdownNow();
+        closeBillingClient();
+        super.handleOnDestroy();
     }
 
     private void closeBillingClient() {
@@ -561,15 +596,7 @@ public class NativePurchasesPlugin extends Plugin {
         );
         QueryProductDetailsParams params = QueryProductDetailsParams.newBuilder().setProductList(productList).build();
         Log.d(TAG, "Initializing billing client for purchase");
-        try {
-            this.initBillingClient(call);
-        } catch (RuntimeException e) {
-            Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
-            closeBillingClient();
-            // Call already rejected in initBillingClient
-            return;
-        }
-        try {
+        withBillingClient(call, () -> {
             Log.d(TAG, "Querying product details for purchase");
             billingClient.queryProductDetailsAsync(
                 params,
@@ -637,11 +664,7 @@ public class NativePurchasesPlugin extends Plugin {
                     }
                 }
             );
-        } catch (Exception e) {
-            Log.d(TAG, "Exception during purchase: " + e.getMessage());
-            closeBillingClient();
-            call.reject(e.getMessage());
-        }
+        });
     }
 
     private void processUnfinishedPurchases() {
@@ -705,17 +728,11 @@ public class NativePurchasesPlugin extends Plugin {
     public void restorePurchases(PluginCall call) {
         Log.d(TAG, "restorePurchases() called");
         Log.d(NativePurchasesPlugin.TAG, "restorePurchases");
-        try {
-            this.initBillingClient(call);
-        } catch (RuntimeException e) {
-            Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
-            closeBillingClient();
-            // Call already rejected in initBillingClient
-            return;
-        }
-        this.processUnfinishedPurchases();
-        call.resolve();
-        Log.d(TAG, "restorePurchases() completed");
+        withBillingClient(call, () -> {
+            this.processUnfinishedPurchases();
+            call.resolve();
+            Log.d(TAG, "restorePurchases() completed");
+        });
     }
 
     private void querySingleProductDetails(String productIdentifier, String productType, PluginCall call) {
@@ -733,15 +750,7 @@ public class NativePurchasesPlugin extends Plugin {
 
         QueryProductDetailsParams params = QueryProductDetailsParams.newBuilder().setProductList(productList).build();
         Log.d(TAG, "Initializing billing client for single product query");
-        try {
-            this.initBillingClient(call);
-        } catch (RuntimeException e) {
-            Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
-            closeBillingClient();
-            // Call already rejected in initBillingClient
-            return;
-        }
-        try {
+        withBillingClient(call, () -> {
             Log.d(TAG, "Querying product details");
             billingClient.queryProductDetailsAsync(
                 params,
@@ -847,11 +856,7 @@ public class NativePurchasesPlugin extends Plugin {
                     }
                 }
             );
-        } catch (Exception e) {
-            Log.d(TAG, "Exception during single product query: " + e.getMessage());
-            closeBillingClient();
-            call.reject(e.getMessage());
-        }
+        });
     }
 
     private void queryProductDetails(List<String> productIdentifiers, String productType, PluginCall call) {
@@ -873,15 +878,7 @@ public class NativePurchasesPlugin extends Plugin {
         Log.d(TAG, "Total products in query list: " + productList.size());
         QueryProductDetailsParams params = QueryProductDetailsParams.newBuilder().setProductList(productList).build();
         Log.d(TAG, "Initializing billing client for product query");
-        try {
-            this.initBillingClient(call);
-        } catch (RuntimeException e) {
-            Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
-            closeBillingClient();
-            // Call already rejected in initBillingClient
-            return;
-        }
-        try {
+        withBillingClient(call, () -> {
             Log.d(TAG, "Querying product details");
             billingClient.queryProductDetailsAsync(
                 params,
@@ -998,11 +995,7 @@ public class NativePurchasesPlugin extends Plugin {
                     }
                 }
             );
-        } catch (Exception e) {
-            Log.d(TAG, "Exception during product query: " + e.getMessage());
-            closeBillingClient();
-            call.reject(e.getMessage());
-        }
+        });
     }
 
     @PluginMethod
@@ -1069,15 +1062,7 @@ public class NativePurchasesPlugin extends Plugin {
             return;
         }
 
-        try {
-            this.initBillingClient(call);
-        } catch (RuntimeException e) {
-            Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
-            closeBillingClient();
-            // Call already rejected in initBillingClient
-            return;
-        }
-
+        withBillingClient(call, () -> {
         JSONArray allPurchases = new JSONArray();
         AtomicInteger pendingQueries = new AtomicInteger((queryInApp ? 1 : 0) + (querySubs ? 1 : 0));
         AtomicBoolean finished = new AtomicBoolean(false);
@@ -1094,7 +1079,6 @@ public class NativePurchasesPlugin extends Plugin {
             }
         };
 
-        try {
             if (queryInApp) {
                 Log.d(TAG, "Querying in-app purchases");
                 QueryPurchasesParams queryInAppParams = QueryPurchasesParams.newBuilder()
@@ -1200,12 +1184,7 @@ public class NativePurchasesPlugin extends Plugin {
                     }
                 });
             }
-        } catch (Exception e) {
-            Log.d(TAG, "Exception during getPurchases: " + e.getMessage());
-            finished.set(true);
-            closeBillingClient();
-            call.reject(e.getMessage());
-        }
+        });
     }
 
     @PluginMethod
@@ -1247,16 +1226,7 @@ public class NativePurchasesPlugin extends Plugin {
         }
 
         Log.d(TAG, "Manually acknowledging purchase with token: " + purchaseToken);
-        try {
-            this.initBillingClient(call);
-        } catch (RuntimeException e) {
-            Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
-            closeBillingClient();
-            // Call already rejected in initBillingClient
-            return;
-        }
-
-        try {
+        withBillingClient(call, () -> {
             AcknowledgePurchaseParams acknowledgePurchaseParams = AcknowledgePurchaseParams.newBuilder()
                 .setPurchaseToken(purchaseToken)
                 .build();
@@ -1281,11 +1251,7 @@ public class NativePurchasesPlugin extends Plugin {
                     }
                 }
             );
-        } catch (Exception e) {
-            Log.d(TAG, "Exception during acknowledgePurchase: " + e.getMessage());
-            closeBillingClient();
-            call.reject(e.getMessage());
-        }
+        });
     }
 
     @PluginMethod
@@ -1300,15 +1266,7 @@ public class NativePurchasesPlugin extends Plugin {
         }
 
         Log.d(TAG, "Consuming purchase with token: " + purchaseToken);
-        try {
-            this.initBillingClient(call);
-        } catch (RuntimeException e) {
-            Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
-            closeBillingClient();
-            return;
-        }
-
-        try {
+        withBillingClient(call, () -> {
             ConsumeParams consumeParams = ConsumeParams.newBuilder().setPurchaseToken(purchaseToken).build();
 
             billingClient.consumeAsync(consumeParams, (billingResult, consumedToken) -> {
@@ -1325,11 +1283,7 @@ public class NativePurchasesPlugin extends Plugin {
                     call.reject("Failed to consume purchase: " + billingResult.getDebugMessage());
                 }
             });
-        } catch (Exception e) {
-            Log.d(TAG, "Exception during consumePurchase: " + e.getMessage());
-            closeBillingClient();
-            call.reject(e.getMessage());
-        }
+        });
     }
 
     @PluginMethod


### PR DESCRIPTION
## Summary
- Move all `BillingClient` initialization off the Capacitor plugin dispatch thread onto a dedicated `NativePurchases-Billing` executor
- Add `withBillingClient()` helper so purchase/query methods return immediately while setup runs in the background
- Reduce setup timeout from 10s×3 attempts to 5s×2 attempts (~11s max on billing thread instead of ~33s)

## Root cause
`initBillingClient()` blocked the plugin thread with `CountDownLatch.await()` while retrying billing connection up to 3 times (10s each). Because Capacitor serializes plugin calls on a shared thread, this froze every other plugin for ~33 seconds when Google Play billing failed to connect.

## Test plan
- [x] `bun run verify` passes locally (iOS, Android, web)
- [ ] On Android device: call `purchaseProduct()` when billing is unavailable — other plugins (Haptics, Share) should remain responsive
- [ ] On Android device: normal purchase flow still works when billing connects

Fixes Cap-go/capacitor-native-purchases#189

Made with [Cursor](https://cursor.com)