### PR TITLE
fix(ios): CapgoNativePurchases.podspec fails with undefined method has_storekit_265_sdk?

### DIFF
--- a/CapgoNativePurchases.podspec
+++ b/CapgoNativePurchases.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-def has_storekit_265_sdk?
+def Pod.has_storekit_265_sdk?
   developer_dirs = [
     ENV['DEVELOPER_DIR'],
     '/Applications/Xcode.app/Contents/Developer'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Fix `CapgoNativePurchases.podspec` so CocoaPods can load it (`pod install` / `pod ipc spec`).
- Change `def has_storekit_265_sdk?` to `def Pod.has_storekit_265_sdk?`.

## Why
- Fixes https://github.com/Cap-go/capacitor-native-purchases/issues/202
- CocoaPods evaluates podspecs via `Pod._eval_podspec` with `self == Pod`. A bare `def` creates an instance method on `Pod`, which bare calls cannot reach, raising `undefined method 'has_storekit_265_sdk?' for module Pod`.

## How
- Define the helper as a singleton method on `Pod` so the existing bare call inside `Pod::Spec.new` resolves correctly (block self remains `Pod`).

## Testing
- Simulated CocoaPods `_eval_podspec` with Ruby: old pattern raises `NoMethodError`, new pattern and the updated podspec both succeed.
- Full `pod ipc spec` / `pod install` not run here (CocoaPods/Xcode not available in this environment).

## Not Tested
- Real `pod install` against an iOS app / Xcode SDK detection path for StoreKit 26.5 flags.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcb04-7d3c-7c76-a3a8-5259d8db2522?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcb04-7d3c-7c76-a3a8-5259d8db2522&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-native-purchases/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

