### PR TITLE
feat(android): surface the Play Billing response code when a purchase is rejected

### DIFF
--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -196,6 +196,41 @@ public class NativePurchasesPlugin extends Plugin {
         }
     }
 
+    /**
+     * Maps a {@link BillingClient.BillingResponseCode} to a readable name so
+     * consumers can tell why a purchase was refused - most importantly
+     * USER_CANCELED (not an error) and ITEM_ALREADY_OWNED (the user already
+     * paid and the app should restore instead of showing a failure).
+     */
+    private static String billingResponseCodeName(int code) {
+        switch (code) {
+            case BillingClient.BillingResponseCode.USER_CANCELED:
+                return "USER_CANCELED";
+            case BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED:
+                return "ITEM_ALREADY_OWNED";
+            case BillingClient.BillingResponseCode.ITEM_NOT_OWNED:
+                return "ITEM_NOT_OWNED";
+            case BillingClient.BillingResponseCode.ITEM_UNAVAILABLE:
+                return "ITEM_UNAVAILABLE";
+            case BillingClient.BillingResponseCode.BILLING_UNAVAILABLE:
+                return "BILLING_UNAVAILABLE";
+            case BillingClient.BillingResponseCode.SERVICE_DISCONNECTED:
+                return "SERVICE_DISCONNECTED";
+            case BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE:
+                return "SERVICE_UNAVAILABLE";
+            case BillingClient.BillingResponseCode.DEVELOPER_ERROR:
+                return "DEVELOPER_ERROR";
+            case BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED:
+                return "FEATURE_NOT_SUPPORTED";
+            case BillingClient.BillingResponseCode.NETWORK_ERROR:
+                return "NETWORK_ERROR";
+            case BillingClient.BillingResponseCode.ERROR:
+                return "ERROR";
+            default:
+                return "UNKNOWN_" + code;
+        }
+    }
+
     private void rejectBillingSetupCall(PluginCall purchaseCall, AtomicBoolean callRejected, String code, String message) {
         if (purchaseCall != null && callRejected.compareAndSet(false, true)) {
             purchaseCall.reject(code, message);
@@ -310,7 +345,7 @@ public class NativePurchasesPlugin extends Plugin {
             Log.d(TAG, "Purchase state is OTHER: " + purchase.getPurchaseState());
             // Handle any other error codes.
             if (purchaseCall != null) {
-                purchaseCall.reject("Purchase is not purchased");
+                purchaseCall.reject("PURCHASE_STATE_" + purchase.getPurchaseState(), "Purchase is not purchased");
             } else {
                 Log.d(TAG, "purchaseCall is null for failed purchase");
             }
@@ -429,7 +464,10 @@ public class NativePurchasesPlugin extends Plugin {
                                 Log.d(TAG, "Purchase update failed or purchases is null");
                                 Log.i(NativePurchasesPlugin.TAG, "onPurchasesUpdated" + billingResult);
                                 if (purchaseCall != null) {
-                                    purchaseCall.reject("Purchase is not purchased");
+                                    purchaseCall.reject(
+                                        billingResponseCodeName(billingResult.getResponseCode()),
+                                        "Purchase is not purchased"
+                                    );
                                 }
                             }
                             closeBillingClient();


### PR DESCRIPTION
### Problem

On Android, every failed purchase is rejected with the same generic string,
regardless of why Play refused it:

```java
// NativePurchasesPlugin.java — onPurchasesUpdated
Log.d(TAG, "Billing result: " + billingResult.getResponseCode() + " - " + billingResult.getDebugMessage());
// ...
purchaseCall.reject("Purchase is not purchased");
```

The response code is logged to logcat on one line and thrown away on the next,
so `USER_CANCELED`, `ITEM_ALREADY_OWNED`, `BILLING_UNAVAILABLE`,
`ITEM_UNAVAILABLE` and `DEVELOPER_ERROR` are indistinguishable from JavaScript.

This has two practical consequences for apps in production:

1. **Users who already own the subscription are shown a payment error.**
   `ITEM_ALREADY_OWNED` is the response Play returns when the user purchased
   moments earlier (or on another account) and the app hasn't reflected it yet.
   The correct recovery is to call `restorePurchases()`, but the app can't know
   that from a generic message, so it shows "payment failed" to someone who has
   already been charged.

2. **User cancellations are counted as failures.** `USER_CANCELED` produces the
   same rejection as a real error, so error metrics are inflated and genuine
   problems are hidden in the noise. This also makes Android inconsistent with
   iOS, where StoreKit surfaces cancellation distinctly.

We hit both cases in a production app: users bought a subscription, tapped
"subscribe" again because the UI hadn't updated, received a payment-error
message, and requested refunds.

### Solution

Pass the Play Billing response code as the Capacitor error code, keeping the
message untouched:

```java
purchaseCall.reject(
    billingResponseCodeName(billingResult.getResponseCode()),
    "Purchase is not purchased"
);
```

Consumers can then branch on `err.code`:

```ts
try {
  await NativePurchases.purchaseProduct({ /* … */ })
} catch (err) {
  if (err.code === 'USER_CANCELED') return          // not an error
  if (err.code === 'ITEM_ALREADY_OWNED') {
    await NativePurchases.restorePurchases()        // the actual fix
    return
  }
  showError(err)
}
```

The same treatment is applied to the `handlePurchase` branch that handles
non-`PURCHASED`/non-`PENDING` states, which surfaces the purchase state as
`PURCHASE_STATE_<n>`.

### Backward compatibility

The rejection **message is unchanged**, so existing consumers matching on the
message string keep working exactly as before. The change only adds a `code`
that was previously absent.

### Notes

- Codes are emitted as readable names rather than raw integers, matching the
  style already used by `rejectBillingSetupCall` (`BILLING_SETUP_FAILED`,
  `BILLING_SETUP_TIMEOUT`, `BILLING_INTERRUPTED`). Unmapped codes fall back to
  `UNKNOWN_<n>` so nothing is silently swallowed.
- iOS is untouched.
- Happy to adapt naming or add the codes to the README/API docs if you prefer —
  just say the word.

### Testing

- `./gradlew :capgo-native-purchases:compileReleaseJavaWithJavac` passes.
- Running in a production app (Play Billing, subscriptions with base plans),
  where `ITEM_ALREADY_OWNED` and `USER_CANCELED` now arrive distinctly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-native-purchases/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790360847&installation_model_id=430928&pr_number=209&repository=Cap-go%2Fcapacitor-native-purchases&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-native-purchases%2Fpull%2F209&signature=1d856299dc87e83a8521509421b1c33b1ab73bef031f73d457d4ea42b7addefe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-native-purchases/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved purchase error reporting with readable billing response codes.
  * Added specific error identifiers for rejected purchase states.
  * Billing flow failures now include clearer diagnostic information alongside the existing message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->