### PR TITLE
feat(android): surface the Play Billing response code when a purchase is rejected

### DIFF
--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -345,7 +345,7 @@ public class NativePurchasesPlugin extends Plugin {
             Log.d(TAG, "Purchase state is OTHER: " + purchase.getPurchaseState());
             // Handle any other error codes.
             if (purchaseCall != null) {
-                purchaseCall.reject("PURCHASE_STATE_" + purchase.getPurchaseState(), "Purchase is not purchased");
+                purchaseCall.reject("Purchase is not purchased", "PURCHASE_STATE_" + purchase.getPurchaseState());
             } else {
                 Log.d(TAG, "purchaseCall is null for failed purchase");
             }
@@ -465,8 +465,8 @@ public class NativePurchasesPlugin extends Plugin {
                                 Log.i(NativePurchasesPlugin.TAG, "onPurchasesUpdated" + billingResult);
                                 if (purchaseCall != null) {
                                     purchaseCall.reject(
-                                        billingResponseCodeName(billingResult.getResponseCode()),
-                                        "Purchase is not purchased"
+                                        "Purchase is not purchased",
+                                        billingResponseCodeName(billingResult.getResponseCode())
                                     );
                                 }
                             }

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -196,6 +196,41 @@ public class NativePurchasesPlugin extends Plugin {
         }
     }
 
+    /**
+     * Maps a {@link BillingClient.BillingResponseCode} to a readable name so
+     * consumers can tell why a purchase was refused - most importantly
+     * USER_CANCELED (not an error) and ITEM_ALREADY_OWNED (the user already
+     * paid and the app should restore instead of showing a failure).
+     */
+    private static String billingResponseCodeName(int code) {
+        switch (code) {
+            case BillingClient.BillingResponseCode.USER_CANCELED:
+                return "USER_CANCELED";
+            case BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED:
+                return "ITEM_ALREADY_OWNED";
+            case BillingClient.BillingResponseCode.ITEM_NOT_OWNED:
+                return "ITEM_NOT_OWNED";
+            case BillingClient.BillingResponseCode.ITEM_UNAVAILABLE:
+                return "ITEM_UNAVAILABLE";
+            case BillingClient.BillingResponseCode.BILLING_UNAVAILABLE:
+                return "BILLING_UNAVAILABLE";
+            case BillingClient.BillingResponseCode.SERVICE_DISCONNECTED:
+                return "SERVICE_DISCONNECTED";
+            case BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE:
+                return "SERVICE_UNAVAILABLE";
+            case BillingClient.BillingResponseCode.DEVELOPER_ERROR:
+                return "DEVELOPER_ERROR";
+            case BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED:
+                return "FEATURE_NOT_SUPPORTED";
+            case BillingClient.BillingResponseCode.NETWORK_ERROR:
+                return "NETWORK_ERROR";
+            case BillingClient.BillingResponseCode.ERROR:
+                return "ERROR";
+            default:
+                return "UNKNOWN_" + code;
+        }
+    }
+
     private void rejectBillingSetupCall(PluginCall purchaseCall, AtomicBoolean callRejected, String code, String message) {
         if (purchaseCall != null && callRejected.compareAndSet(false, true)) {
             purchaseCall.reject(code, message);
@@ -310,7 +345,7 @@ public class NativePurchasesPlugin extends Plugin {
             Log.d(TAG, "Purchase state is OTHER: " + purchase.getPurchaseState());
             // Handle any other error codes.
             if (purchaseCall != null) {
-                purchaseCall.reject("Purchase is not purchased");
+                purchaseCall.reject("PURCHASE_STATE_" + purchase.getPurchaseState(), "Purchase is not purchased");
             } else {
                 Log.d(TAG, "purchaseCall is null for failed purchase");
             }
@@ -429,7 +464,10 @@ public class NativePurchasesPlugin extends Plugin {
                                 Log.d(TAG, "Purchase update failed or purchases is null");
                                 Log.i(NativePurchasesPlugin.TAG, "onPurchasesUpdated" + billingResult);
                                 if (purchaseCall != null) {
-                                    purchaseCall.reject("Purchase is not purchased");
+                                    purchaseCall.reject(
+                                        billingResponseCodeName(billingResult.getResponseCode()),
+                                        "Purchase is not purchased"
+                                    );
                                 }
                             }
                             closeBillingClient();


### PR DESCRIPTION
Same-repo copy of fork PR #209, rebased onto current `main` so required CI can run without the fork `action_required` / behind-main UNSTABLE merge state.

Fork PR left open: https://github.com/Cap-go/capacitor-native-purchases/pull/209
Head: `4476edd` on `Cap-go/feat/android-billing-response-code`

## What
On Android, pass the Play Billing response code as the Capacitor error `code` (message unchanged). Apps can distinguish `USER_CANCELED`, `ITEM_ALREADY_OWNED`, etc.

## Why
Every failed purchase was rejected with the same generic string. Users who already owned a subscription saw a payment error; cancellations were counted as failures.

## Compatibility
Rejection **message is unchanged**. Additive `code` only. iOS untouched.

## Testing
- Feature already reviewed/approved on fork #209 HEAD `f9d22a7`
- This PR exists so same-repo required checks can go green and merge CLEAN

Do not merge the fork PR. Prefer this one once CLEAN + CR APPROVED on HEAD + 0 threads.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-native-purchases/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790413692&installation_model_id=430928&pr_number=210&repository=Cap-go%2Fcapacitor-native-purchases&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-native-purchases%2Fpull%2F210&signature=ad101810aac787ebe2b627b00a67fdf5eb03499c0533a454955af5b05fd9bd91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-native-purchases/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Purchase errors now include clearer, standardized error codes.
  * Improved error details for unsuccessful purchases and billing response failures.
  * Unrecognized billing responses now include their numeric code for easier diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->