### PR TITLE
fix(android): reject getPurchases when a Play purchase query fails

### DIFF
--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -39,6 +39,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.json.JSONArray;
 
 @CapacitorPlugin(name = "NativePurchases")
@@ -229,6 +230,18 @@ public class NativePurchasesPlugin extends Plugin {
             default:
                 return "UNKNOWN_" + code;
         }
+    }
+
+    private static String describeQueryFailure(String productType, BillingResult billingResult) {
+        return (
+            productType +
+            ": " +
+            billingResponseCodeName(billingResult.getResponseCode()) +
+            " (" +
+            billingResult.getResponseCode() +
+            ") " +
+            billingResult.getDebugMessage()
+        );
     }
 
     private void rejectBillingSetupCall(PluginCall purchaseCall, AtomicBoolean callRejected, String code, String message) {
@@ -1141,15 +1154,25 @@ public class NativePurchasesPlugin extends Plugin {
             JSONArray allPurchases = new JSONArray();
             AtomicInteger pendingQueries = new AtomicInteger((queryInApp ? 1 : 0) + (querySubs ? 1 : 0));
             AtomicBoolean finished = new AtomicBoolean(false);
+            // A query that fails must not be reported as "no purchases": callers use an
+            // empty list to revoke entitlements, so a transient Play error would strip
+            // a paying user. Remember the first failure and reject instead.
+            AtomicReference<String> queryFailure = new AtomicReference<>(null);
 
             Runnable maybeFinish = () -> {
                 int remaining = pendingQueries.decrementAndGet();
                 Log.d(TAG, "Pending purchase queries remaining: " + remaining);
                 if (remaining <= 0 && finished.compareAndSet(false, true)) {
+                    closeBillingClient();
+                    String failure = queryFailure.get();
+                    if (failure != null) {
+                        Log.w(TAG, "Rejecting getPurchases: " + failure);
+                        call.reject("Failed to query purchases: " + failure, "QUERY_PURCHASES_FAILED");
+                        return;
+                    }
                     JSObject result = new JSObject();
                     result.put("purchases", allPurchases);
                     Log.d(TAG, "Returning " + allPurchases.length() + " purchases");
-                    closeBillingClient();
                     call.resolve(result);
                 }
             };
@@ -1198,9 +1221,11 @@ public class NativePurchasesPlugin extends Plugin {
                             }
                         } else {
                             Log.d(TAG, "In-app purchase query failed: " + billingResult.getDebugMessage());
+                            queryFailure.compareAndSet(null, describeQueryFailure("inapp", billingResult));
                         }
                     } catch (Exception ex) {
                         Log.d(TAG, "Error processing in-app purchase query: " + ex.getMessage());
+                        queryFailure.compareAndSet(null, "inapp: " + ex.getMessage());
                     } finally {
                         maybeFinish.run();
                     }
@@ -1251,9 +1276,11 @@ public class NativePurchasesPlugin extends Plugin {
                             }
                         } else {
                             Log.d(TAG, "Subscription purchase query failed: " + billingResult.getDebugMessage());
+                            queryFailure.compareAndSet(null, describeQueryFailure("subs", billingResult));
                         }
                     } catch (Exception ex) {
                         Log.d(TAG, "Error processing subscription purchase query: " + ex.getMessage());
+                        queryFailure.compareAndSet(null, "subs: " + ex.getMessage());
                     } finally {
                         maybeFinish.run();
                     }

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -1225,7 +1225,7 @@ public class NativePurchasesPlugin extends Plugin {
                         }
                     } catch (Exception ex) {
                         Log.d(TAG, "Error processing in-app purchase query: " + ex.getMessage());
-                        queryFailure.compareAndSet(null, "inapp: " + ex.getMessage());
+                        queryFailure.compareAndSet(null, describeQueryFailure("inapp", billingResult) + " / " + ex.getMessage());
                     } finally {
                         maybeFinish.run();
                     }
@@ -1280,7 +1280,7 @@ public class NativePurchasesPlugin extends Plugin {
                         }
                     } catch (Exception ex) {
                         Log.d(TAG, "Error processing subscription purchase query: " + ex.getMessage());
-                        queryFailure.compareAndSet(null, "subs: " + ex.getMessage());
+                        queryFailure.compareAndSet(null, describeQueryFailure("subs", billingResult) + " / " + ex.getMessage());
                     } finally {
                         maybeFinish.run();
                     }


### PR DESCRIPTION
## What
- Android `getPurchases()` now rejects (code `QUERY_PURCHASES_FAILED`) when `queryPurchasesAsync` returns a non-OK `BillingResult` for the in-app or subscription query, or when processing a result throws.
- The rejection message names the failed product type, the Play response code (via the existing `billingResponseCodeName` helper) and the debug message, e.g. `Failed to query purchases: subs: SERVICE_DISCONNECTED (-1) ...`.
- Successful queries are unchanged: same `{ purchases: [...] }` shape, same fields.

## Why
- Today a failed query is logged and then reported as an empty list, so the caller cannot tell "the user owns nothing" from "Play could not be reached". Apps that revoke entitlements when the list is empty (the usual way to reflect refunds and expired subscriptions on Android) will strip a paying user during a transient Play Services / network hiccup, and restore them only on a later successful launch.
- The documented contract already says the method throws when the query fails (`@throws An error if the purchase query fails` on `getPurchases` in `src/definitions.ts`), and the billing-client setup path already rejects on connection failure. This change makes the query path honor the same contract, so callers that handle rejection today keep working and can now trust an empty list.

## How
- Track the first failure in an `AtomicReference<String>` next to the existing `pendingQueries` / `finished` counters.
- Both `queryPurchasesAsync` callbacks record a failure in their non-OK branch and in their `catch`, then fall through to the existing `finally { maybeFinish.run(); }`, so the second query still completes and the billing client is still closed exactly once.
- `maybeFinish` closes the client first (as before) and then either rejects with the recorded failure or resolves with the collected purchases.
- No changes to `src/definitions.ts` or the README: the documented behavior is what is now implemented.

## Testing
- `bunx prettier --check` with `prettier-plugin-java` on the changed file: passes.
- `cd android && ./gradlew build test` with JDK 21 and the Android SDK: compiles, lint clean, existing unit tests pass.
- Read through the failure branches against Play Billing Library 9.1.0 `queryPurchasesAsync` semantics (non-OK `BillingResult` with a possibly null list).

## Not Tested
- Not exercised on a device with a forced Play failure (e.g. Play Store disabled / network cut mid-query). The change only touches the two existing failure branches, which currently log and continue; a device test would confirm the promise rejects with `QUERY_PURCHASES_FAILED` in that situation.
- iOS is untouched.

---
Transparency: this PR was written by an AI agent (Claude Code) on behalf of the account owner, who reviewed the change and asked for it to be submitted. Happy to adjust to a non-rejecting shape (e.g. an extra `error` field on the resolved value) if you prefer to keep the resolve path for callers that never handled rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-native-purchases/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791375667&installation_model_id=430928&pr_number=215&repository=Cap-go%2Fcapacitor-native-purchases&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-native-purchases%2Fpull%2F215&signature=2fa55f669c7ab9c403dd6961704eb26338c14446c992bb4202225834d78ee312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-native-purchases/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Purchase queries now report a clear failure when in-app product or subscription retrieval fails, instead of returning an empty purchase list.
  * Query failures now include an error code and descriptive details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->